### PR TITLE
store wireframe 작업 ZERO-22

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,15 +1,13 @@
 module.exports = {
-  "stories": [
-    "../src/**/*.stories.mdx",
-    "../src/**/*.stories.@(js|jsx|ts|tsx)"
-  ],
-  "addons": [
+  stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
+  addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",
-    "@storybook/addon-interactions"
+    "@storybook/addon-interactions",
+    "@storybook/addon-actions",
   ],
-  "framework": "@storybook/react",
-  "core": {
-    "builder": "@storybook/builder-webpack5"
-  }
-}
+  framework: "@storybook/react",
+  core: {
+    builder: "@storybook/builder-webpack5",
+  },
+};

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,13 @@
-import "../src/index.css";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+
+export const decorators = [
+  Story => (
+    <>
+      <MemoryRouter initialEntries={["/"]}>{Story()}</MemoryRouter>
+    </>
+  ),
+];
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,12 @@
         "axios": "^1.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-error-boundary": "^3.1.4",
         "react-query": "^3.39.2",
         "react-router-dom": "^6.4.4",
         "recoil": "^0.7.6",
-        "styled-components": "^5.3.6"
+        "styled-components": "^5.3.6",
+        "styled-reset": "^4.4.5"
       },
       "devDependencies": {
         "@babel/core": "^7.20.5",
@@ -25,7 +27,7 @@
         "@babel/preset-react": "^7.18.6",
         "@babel/preset-typescript": "^7.18.6",
         "@babel/runtime-corejs3": "^7.20.6",
-        "@storybook/addon-actions": "^6.5.14",
+        "@storybook/addon-actions": "^6.5.15",
         "@storybook/addon-essentials": "^6.5.14",
         "@storybook/addon-interactions": "^6.5.14",
         "@storybook/addon-links": "^6.5.14",
@@ -4593,18 +4595,18 @@
       }
     },
     "node_modules/@storybook/addon-actions": {
-      "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-6.5.14.tgz",
-      "integrity": "sha512-fZt8bn+oCsVDv9yuZfKL4lq77V5EqW60khHpOxLRRK69hMsE+gaylK0O5l/pelVf3Jf3+TablUG+2xWTaJHGlQ==",
+      "version": "6.5.15",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-6.5.15.tgz",
+      "integrity": "sha512-cnLzVK1S+EydFDSuvxMmMAxVqNXijBGdV9QTgsu6ys5sOkoiXRETKZmxuN8/ZRbkfc4N+1KAylSCZOOHzBQTBQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/addons": "6.5.14",
-        "@storybook/api": "6.5.14",
-        "@storybook/client-logger": "6.5.14",
-        "@storybook/components": "6.5.14",
-        "@storybook/core-events": "6.5.14",
+        "@storybook/addons": "6.5.15",
+        "@storybook/api": "6.5.15",
+        "@storybook/client-logger": "6.5.15",
+        "@storybook/components": "6.5.15",
+        "@storybook/core-events": "6.5.15",
         "@storybook/csf": "0.0.2--canary.4566f4d.1",
-        "@storybook/theming": "6.5.14",
+        "@storybook/theming": "6.5.15",
         "core-js": "^3.8.2",
         "fast-deep-equal": "^3.1.3",
         "global": "^4.4.0",
@@ -4633,6 +4635,173 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@storybook/addon-actions/node_modules/@storybook/addons": {
+      "version": "6.5.15",
+      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.5.15.tgz",
+      "integrity": "sha512-xT31SuSX+kYGyxCNK2nqL7WTxucs3rSmhiCLovJcUjYk+QquV3c2c53Ki7lwwdDbzfXFcNAe0HJ4hoTN4jhn0Q==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/api": "6.5.15",
+        "@storybook/channels": "6.5.15",
+        "@storybook/client-logger": "6.5.15",
+        "@storybook/core-events": "6.5.15",
+        "@storybook/csf": "0.0.2--canary.4566f4d.1",
+        "@storybook/router": "6.5.15",
+        "@storybook/theming": "6.5.15",
+        "@types/webpack-env": "^1.16.0",
+        "core-js": "^3.8.2",
+        "global": "^4.4.0",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-actions/node_modules/@storybook/api": {
+      "version": "6.5.15",
+      "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.5.15.tgz",
+      "integrity": "sha512-BBE0KXKvj1/3jTghbIoWfrcDM0t+xO7EYtWWAXD6XlhGsZVD2Dy82Z52ONyLulMDRpMWl0OYy3h6A1YnFUH25w==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "6.5.15",
+        "@storybook/client-logger": "6.5.15",
+        "@storybook/core-events": "6.5.15",
+        "@storybook/csf": "0.0.2--canary.4566f4d.1",
+        "@storybook/router": "6.5.15",
+        "@storybook/semver": "^7.3.2",
+        "@storybook/theming": "6.5.15",
+        "core-js": "^3.8.2",
+        "fast-deep-equal": "^3.1.3",
+        "global": "^4.4.0",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "regenerator-runtime": "^0.13.7",
+        "store2": "^2.12.0",
+        "telejson": "^6.0.8",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-actions/node_modules/@storybook/channels": {
+      "version": "6.5.15",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.5.15.tgz",
+      "integrity": "sha512-gPpsBgirv2NCXbH4WbYqdkI0JLE96aiVuu7UEWfn9yu071pQ9CLHbhXGD9fSFNrfOkyBBY10ppSE7uCXw3Wexg==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-actions/node_modules/@storybook/client-logger": {
+      "version": "6.5.15",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.5.15.tgz",
+      "integrity": "sha512-0uyxKvodq+FycGv6aUwC1wUR6suXf2+7ywMFAOlYolI4UvNj8NyU/5AfgKT5XnxYAgPmoCiAjOE700TrfHrosw==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2",
+        "global": "^4.4.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-actions/node_modules/@storybook/components": {
+      "version": "6.5.15",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.5.15.tgz",
+      "integrity": "sha512-bHTT0Oa3s4g+MBMaLBbX9ofMtb1AW59AzIUNGrfqW1XqJMGuUHMiJ7TSo+i5dRSFpbFygnwMEG9LfHxpR2Z0Dw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "6.5.15",
+        "@storybook/csf": "0.0.2--canary.4566f4d.1",
+        "@storybook/theming": "6.5.15",
+        "core-js": "^3.8.2",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "regenerator-runtime": "^0.13.7",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-actions/node_modules/@storybook/core-events": {
+      "version": "6.5.15",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.5.15.tgz",
+      "integrity": "sha512-B1Ba6l5W7MeNclclqMMTMHgYgfdpB5SIhNCQFnzIz8blynzRhNFMdxvbAl6Je5G0S4xydYYd7Lno2kXQebs7HA==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-actions/node_modules/@storybook/router": {
+      "version": "6.5.15",
+      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.5.15.tgz",
+      "integrity": "sha512-9t8rI8t7/Krolau29gsdjdbRQ66orONIyP0efp0EukVgv6reNFzb/U14ARrl0uHys6Tl5Xyece9FoakQUdn8Kg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "6.5.15",
+        "core-js": "^3.8.2",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-actions/node_modules/@storybook/theming": {
+      "version": "6.5.15",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.5.15.tgz",
+      "integrity": "sha512-pgdW0lVZKKXQ4VhIfLHycMmwFSVOY7vLTKnytag4Y8Yz+aXm0bwDN/QxPntFzDH47F1Rcy2ywNnvty8ooDTvuA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "6.5.15",
+        "core-js": "^3.8.2",
+        "memoizerific": "^1.11.3",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@storybook/addon-backgrounds": {
@@ -4911,6 +5080,49 @@
           "optional": true
         },
         "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/addon-essentials/node_modules/@storybook/addon-actions": {
+      "version": "6.5.14",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-6.5.14.tgz",
+      "integrity": "sha512-fZt8bn+oCsVDv9yuZfKL4lq77V5EqW60khHpOxLRRK69hMsE+gaylK0O5l/pelVf3Jf3+TablUG+2xWTaJHGlQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "6.5.14",
+        "@storybook/api": "6.5.14",
+        "@storybook/client-logger": "6.5.14",
+        "@storybook/components": "6.5.14",
+        "@storybook/core-events": "6.5.14",
+        "@storybook/csf": "0.0.2--canary.4566f4d.1",
+        "@storybook/theming": "6.5.14",
+        "core-js": "^3.8.2",
+        "fast-deep-equal": "^3.1.3",
+        "global": "^4.4.0",
+        "lodash": "^4.17.21",
+        "polished": "^4.2.2",
+        "prop-types": "^15.7.2",
+        "react-inspector": "^5.1.0",
+        "regenerator-runtime": "^0.13.7",
+        "telejson": "^6.0.8",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2",
+        "uuid-browser": "^3.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
           "optional": true
         }
       }
@@ -26990,6 +27202,21 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-inspector": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-5.1.1.tgz",
@@ -29430,6 +29657,17 @@
         "react": ">= 16.8.0",
         "react-dom": ">= 16.8.0",
         "react-is": ">= 16.8.0"
+      }
+    },
+    "node_modules/styled-reset": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.4.5.tgz",
+      "integrity": "sha512-uEQzbCqSBbx1ZT9VuquoGOJyVzs3kMIMCyjxmtSo4/JoTCrq92UFTJx91KcdMncDaymz6NE8sgSvstHHcJjExg==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "styled-components": ">=4.0.0 || >=5.0.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "axios": "^1.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^3.1.4",
     "react-query": "^3.39.2",
     "react-router-dom": "^6.4.4",
     "recoil": "^0.7.6",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,18 +5,23 @@ import Home from "./pages/Home";
 import Login from "./pages/Login";
 import Mypage from "./pages/Mypage";
 import Signup from "./pages/Signup";
-import Store from "./pages/Store";
+import ProductList from "./pages/Store/ProductList";
+import ProductDetail from "./pages/Store/ProductDetail";
+
 function App() {
   return (
-    <Routes>
-      <Route path="/" element={<Home />} />
-      <Route path="/store" element={<Store />} />
-      <Route path="/contents" element={<Contents />} />
-      <Route path="/community" element={<Community />} />
-      <Route path="/mypage" element={<Mypage />} />
-      <Route path="/signup" element={<Signup />} />
-      <Route path="/login" element={<Login />} />
-    </Routes>
+    <>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/store" element={<ProductList />} />
+        <Route path="/store/product/:id" element={<ProductDetail />} />
+        <Route path="/contents" element={<Contents />} />
+        <Route path="/community" element={<Community />} />
+        <Route path="/mypage" element={<Mypage />} />
+        <Route path="/signup" element={<Signup />} />
+        <Route path="/login" element={<Login />} />
+      </Routes>
+    </>
   );
 }
 

--- a/src/components/Common/Pagenation/Pagenation.stories.tsx
+++ b/src/components/Common/Pagenation/Pagenation.stories.tsx
@@ -1,0 +1,16 @@
+import { action } from "@storybook/addon-actions";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import Pagenation from "./Pagenation";
+
+export default {
+  title: "Common/Pagenation",
+  component: Pagenation,
+} as ComponentMeta<typeof Pagenation>;
+
+const Template: ComponentStory<typeof Pagenation> = args => <Pagenation {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  pagelist: [1, 2, 3, 4, 5],
+  movePage: action("이동"),
+};

--- a/src/components/Common/Pagenation/Pagenation.styles.ts
+++ b/src/components/Common/Pagenation/Pagenation.styles.ts
@@ -1,0 +1,20 @@
+import styled from "styled-components";
+
+export const PagenationLayout = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 5px;
+  margin: 10px 0 0 0;
+`;
+
+export const PagenationMoveButton = styled.button`
+  width: 25px;
+  height: 25px;
+`;
+
+export const PagenationNumberButton = styled.button<{ selected: boolean }>`
+  width: 25px;
+  height: 25px;
+  font-weight: ${props => (props.selected ? "600" : "400")};
+  color: ${props => (props.selected ? "#000000" : "#CACACA")};
+`;

--- a/src/components/Common/Pagenation/Pagenation.tsx
+++ b/src/components/Common/Pagenation/Pagenation.tsx
@@ -1,0 +1,19 @@
+import { PagenationLayout, PagenationMoveButton, PagenationNumberButton } from "./Pagenation.styles";
+
+const Pagenation = ({ curpage, pagelist, movePage }: any) => {
+  return (
+    <PagenationLayout>
+      <PagenationMoveButton>&lt;</PagenationMoveButton>
+      {pagelist.map(el => {
+        return (
+          <PagenationNumberButton key={el} onClick={() => movePage(el)} selected={curpage === el}>
+            {el}
+          </PagenationNumberButton>
+        );
+      })}
+      <PagenationMoveButton>&gt;</PagenationMoveButton>
+    </PagenationLayout>
+  );
+};
+
+export default Pagenation;

--- a/src/components/Store/Common/CategoryNavigation/CategoryNavigation.stories.tsx
+++ b/src/components/Store/Common/CategoryNavigation/CategoryNavigation.stories.tsx
@@ -1,0 +1,16 @@
+import { action } from "@storybook/addon-actions";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import CategoryNavigation from "./CategoryNavigation";
+
+export default {
+  title: "Store/Common/CategoryNavigation",
+  component: CategoryNavigation,
+} as ComponentMeta<typeof CategoryNavigation>;
+
+const Template: ComponentStory<typeof CategoryNavigation> = args => <CategoryNavigation {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  condition: { category: "전체", filter: [], sort: "인기순", page: 1 },
+  setCondition: action("카테고리 변경"),
+};

--- a/src/components/Store/Common/CategoryNavigation/CategoryNavigation.styles.ts
+++ b/src/components/Store/Common/CategoryNavigation/CategoryNavigation.styles.ts
@@ -1,0 +1,20 @@
+import styled from "styled-components";
+
+export const CategoryNavigationLayout = styled.nav`
+  width: 100%;
+  border-bottom: 1px solid #eaeaea;
+`;
+
+export const CategoryNavigationRow = styled.ul`
+  width: 1200px;
+  display: flex;
+  gap: 30px;
+  margin: auto;
+`;
+
+export const CategoryNavigationItem = styled.li<{ same: boolean }>`
+  font-weight: 700;
+  font-size: 24px;
+  border-bottom: ${props => (props.same ? "2px solid black" : "none")};
+  padding: 20px 0;
+`;

--- a/src/components/Store/Common/CategoryNavigation/CategoryNavigation.tsx
+++ b/src/components/Store/Common/CategoryNavigation/CategoryNavigation.tsx
@@ -1,0 +1,40 @@
+import { Link } from "react-router-dom";
+import { conditionType, setConditionType } from "../../../../pages/Store/ProductList";
+import { CategoryNavigationItem, CategoryNavigationLayout, CategoryNavigationRow } from "./CategoryNavigation.styles";
+
+interface CategoryNavigationProps {
+  condition: conditionType;
+  setCondition: setConditionType;
+}
+
+const CategoryNavigation = ({ condition, setCondition }: CategoryNavigationProps) => {
+  console.log(condition);
+  return (
+    <CategoryNavigationLayout>
+      <CategoryNavigationRow>
+        {[
+          "베스트",
+          "전체",
+          "식품",
+          "주방",
+          "욕실",
+          "생활",
+          "취미",
+          "선물",
+          "여성용품",
+          "반려동물",
+          "문구",
+          "이벤트",
+        ].map(category => (
+          <CategoryNavigationItem key={category} same={category === condition.category}>
+            <Link to={`/store?category=${category}`} onClick={() => setCondition({ ...condition, category })}>
+              {category}
+            </Link>
+          </CategoryNavigationItem>
+        ))}
+      </CategoryNavigationRow>
+    </CategoryNavigationLayout>
+  );
+};
+
+export default CategoryNavigation;

--- a/src/components/Store/Common/ProductCard/ProductCard.stories.tsx
+++ b/src/components/Store/Common/ProductCard/ProductCard.stories.tsx
@@ -1,0 +1,23 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import ProductCard from "./ProductCard";
+
+export default {
+  title: "Store/Common/ProductCard",
+  component: ProductCard,
+} as ComponentMeta<typeof ProductCard>;
+
+const Template: ComponentStory<typeof ProductCard> = args => (
+  <div style={{ width: "270px", height: "430px;" }}>
+    <ProductCard {...args} />
+  </div>
+);
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  brand: "그리너스",
+  title: "마일드 고체치약 30정입",
+  discountRate: "45",
+  price: "5900",
+  badges: ["best", "sale"],
+  liked: true,
+};

--- a/src/components/Store/Common/ProductCard/ProductCard.styles.ts
+++ b/src/components/Store/Common/ProductCard/ProductCard.styles.ts
@@ -1,0 +1,81 @@
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+
+export const ProductCardLayout = styled.article`
+  width: 100%;
+  position: relative;
+`;
+
+export const ProductCardCol = styled(Link)`
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+`;
+
+export const ProductCardImgBox = styled.div`
+  position: relative;
+  width: 100%;
+  padding-bottom: 100%;
+`;
+
+export const ProductCardImg = styled.img`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0%;
+  background-color: #d9d9d9;
+  border-radius: 10px;
+`;
+
+export const ProductCardInfoList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+export const ProductCardBrand = styled.div`
+  font-weight: 500;
+  font-size: 14px;
+`;
+
+export const ProductCardTitle = styled.div`
+  font-weight: 500;
+  font-size: 18px;
+`;
+export const ProductCardPriceBox = styled.div`
+  display: flex;
+  gap: 10px;
+`;
+export const ProductCardDiscountRate = styled.div`
+  font-weight: 600;
+  font-size: 18px;
+`;
+export const ProductCardPrice = styled.div`
+  font-weight: 600;
+  font-size: 18px;
+`;
+
+export const ProductCardBadgeList = styled.ul`
+  display: flex;
+  gap: 10px;
+`;
+
+export const ProductCardBadgeItem = styled.li`
+  width: 60px;
+  height: 25px;
+  border-radius: 5px;
+  background: #ffb1b1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const ProdcutCardLikeIcon = styled.div`
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  font-size: 35px;
+  color: white;
+  z-index: 10;
+`;

--- a/src/components/Store/Common/ProductCard/ProductCard.tsx
+++ b/src/components/Store/Common/ProductCard/ProductCard.tsx
@@ -1,0 +1,74 @@
+import { AxiosResponse } from "axios";
+import { UseMutateFunction } from "react-query";
+import {
+  ProductCardLayout,
+  ProductCardImg,
+  ProductCardCol,
+  ProductCardInfoList,
+  ProductCardBadgeList,
+  ProductCardBadgeItem,
+  ProductCardImgBox,
+  ProductCardBrand,
+  ProductCardTitle,
+  ProductCardPriceBox,
+  ProductCardDiscountRate,
+  ProductCardPrice,
+  ProdcutCardLikeIcon,
+} from "./ProductCard.styles";
+
+export interface ProductCardProps {
+  id: number;
+  brand: string;
+  title: string;
+  discountRate: string;
+  price: string;
+  badges: string[];
+  liked: boolean;
+  category: string;
+  changeLiked: UseMutateFunction<AxiosResponse<unknown, unknown>, unknown, unknown, unknown>;
+}
+
+const ProductCard = ({
+  category,
+  id,
+  brand,
+  title,
+  discountRate,
+  price,
+  badges,
+  liked,
+  changeLiked,
+}: ProductCardProps) => {
+  return (
+    <ProductCardLayout>
+      <ProductCardCol to={`/store/product/${id}`} state={{ category }}>
+        <ProductCardImgBox>
+          <ProductCardImg />
+          <ProdcutCardLikeIcon
+            onClick={e => {
+              e.preventDefault();
+              changeLiked(id);
+            }}
+          >
+            {liked ? "♥" : "♡"}
+          </ProdcutCardLikeIcon>
+        </ProductCardImgBox>
+        <ProductCardInfoList>
+          <ProductCardBrand>{brand}</ProductCardBrand>
+          <ProductCardTitle>{title}</ProductCardTitle>
+          <ProductCardPriceBox>
+            <ProductCardDiscountRate>{discountRate}%</ProductCardDiscountRate>
+            <ProductCardPrice>{price}원</ProductCardPrice>
+          </ProductCardPriceBox>
+          <ProductCardBadgeList>
+            {badges.map(badge => (
+              <ProductCardBadgeItem key={badge}>{badge}</ProductCardBadgeItem>
+            ))}
+          </ProductCardBadgeList>
+        </ProductCardInfoList>
+      </ProductCardCol>
+    </ProductCardLayout>
+  );
+};
+
+export default ProductCard;

--- a/src/components/Store/ProductDetail/Detail/Ask/Ask.stories.tsx
+++ b/src/components/Store/ProductDetail/Detail/Ask/Ask.stories.tsx
@@ -1,0 +1,68 @@
+import { action } from "@storybook/addon-actions";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import Ask from "./Ask";
+
+export default {
+  title: "Store/ProductDetail/Detail/Ask",
+  component: Ask,
+} as ComponentMeta<typeof Ask>;
+
+const Template: ComponentStory<typeof Ask> = args => <Ask {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  page: 1,
+  setPage: action("페이지이동"),
+  sort: "베스트순",
+  setSort: action("정렬변경"),
+  data: {
+    totalElement: 456,
+    categoryElement: [156, 106, 10, 30, 10],
+    content: [
+      {
+        id: 1,
+        title: "이번달에 살 수 있나요?",
+        category: "제품문의",
+        nickname: "grenus",
+        date: "2023.01.03",
+        content: "린스바만 계속 기다리는데 재입고 언제될까요?ㅠㅠ 빨리 입고해주세요",
+        answer:
+          "안녕하세요 동구밭 입니다 =] 문의 주신 린스바는 원료 수급이 원활하지 못해 제작 과정에 어려움을 겪고 있었으나, 현재 원료 확보된 상태로 밤낮으로 생산에 힘을 쓰고 있어 6월 중순 입고될 예정입니다ㅜㅜ빠른 입고 될 수 있도록 최대한 노력하겠습니다. 동구밭을 찾아주셔서 감사합니다! 좋은 하루 보내세요 = ]",
+        secret: true,
+      },
+      {
+        id: 2,
+        title: "이번달에 살 수 있나요?",
+        category: "재입고문의",
+        nickname: "grenus",
+        date: "2023.01.03",
+        content: "린스바만 계속 기다리는데 재입고 언제될까요?ㅠㅠ 빨리 입고해주세요",
+        answer:
+          "안녕하세요 동구밭 입니다 =] 문의 주신 린스바는 원료 수급이 원활하지 못해 제작 과정에 어려움을 겪고 있었으나, 현재 원료 확보된 상태로 밤낮으로 생산에 힘을 쓰고 있어 6월 중순 입고될 예정입니다ㅜㅜ빠른 입고 될 수 있도록 최대한 노력하겠습니다. 동구밭을 찾아주셔서 감사합니다! 좋은 하루 보내세요 = ]",
+        secret: false,
+      },
+      {
+        id: 3,
+        title: "이번달에 살 수 있나요?",
+        category: "배송문의",
+        nickname: "grenus",
+        date: "2023.01.03",
+        content: "린스바만 계속 기다리는데 재입고 언제될까요?ㅠㅠ 빨리 입고해주세요",
+        answer:
+          "안녕하세요 동구밭 입니다 =] 문의 주신 린스바는 원료 수급이 원활하지 못해 제작 과정에 어려움을 겪고 있었으나, 현재 원료 확보된 상태로 밤낮으로 생산에 힘을 쓰고 있어 6월 중순 입고될 예정입니다ㅜㅜ빠른 입고 될 수 있도록 최대한 노력하겠습니다. 동구밭을 찾아주셔서 감사합니다! 좋은 하루 보내세요 = ]",
+        secret: false,
+      },
+      {
+        id: 4,
+        title: "이번달에 살 수 있나요?",
+        category: "기타",
+        nickname: "grenus",
+        date: "2023.01.03",
+        content: "린스바만 계속 기다리는데 재입고 언제될까요?ㅠㅠ 빨리 입고해주세요",
+        answer:
+          "안녕하세요 동구밭 입니다 =] 문의 주신 린스바는 원료 수급이 원활하지 못해 제작 과정에 어려움을 겪고 있었으나, 현재 원료 확보된 상태로 밤낮으로 생산에 힘을 쓰고 있어 6월 중순 입고될 예정입니다ㅜㅜ빠른 입고 될 수 있도록 최대한 노력하겠습니다. 동구밭을 찾아주셔서 감사합니다! 좋은 하루 보내세요 = ]",
+        secret: false,
+      },
+    ],
+  },
+};

--- a/src/components/Store/ProductDetail/Detail/Ask/Ask.styles.ts
+++ b/src/components/Store/ProductDetail/Detail/Ask/Ask.styles.ts
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+
+export const AskLayout = styled.div`
+  width: 100%;
+  padding: 100px 0 0 0;
+`;
+
+export const AskTopBox = styled.div`
+  display: flex;
+  border-bottom: 1px solid #eaeaea;
+  max-width: 1200px;
+  margin: auto;
+  padding: 0 0 20px 0;
+`;
+
+export const AskTitle = styled.div`
+  font-weight: 600;
+`;

--- a/src/components/Store/ProductDetail/Detail/Ask/Ask.tsx
+++ b/src/components/Store/ProductDetail/Detail/Ask/Ask.tsx
@@ -1,0 +1,29 @@
+import Pagenation from "../../../../Common/Pagenation/Pagenation";
+import { AskLayout, AskTitle, AskTopBox } from "./Ask.styles";
+import { AskDataType } from "./AskContainer";
+import AskList from "./AskList/AskList";
+import CategoryNavigation from "./CategoryNavigation/CategoryNavigation";
+
+interface AskProps {
+  page: number;
+  setPage: React.Dispatch<React.SetStateAction<number>>;
+  sort: string;
+  setSort: React.Dispatch<React.SetStateAction<string>>;
+  askRef: React.RefObject<HTMLDivElement>;
+  data: AskDataType;
+}
+
+const Ask = ({ page, setPage, sort, setSort, data: { content, totalElement, categoryElement }, askRef }: AskProps) => {
+  return (
+    <AskLayout ref={askRef}>
+      <AskTopBox>
+        <AskTitle>문의 {totalElement}</AskTitle>
+        <CategoryNavigation sort={sort} setSort={setSort} counts={categoryElement} />
+      </AskTopBox>
+      <AskList data={content} />
+      <Pagenation curpage={page} pagelist={[1, 2, 3, 4, 5]} movePage={setPage} />
+    </AskLayout>
+  );
+};
+
+export default Ask;

--- a/src/components/Store/ProductDetail/Detail/Ask/AskContainer.tsx
+++ b/src/components/Store/ProductDetail/Detail/Ask/AskContainer.tsx
@@ -1,0 +1,36 @@
+import useSortPaging from "../../../../../hooks/useSortPaging";
+import useSuspenseQuery from "../../../../../hooks/useSuspenseQuery";
+import Ask from "./Ask";
+
+export interface AskDataContentType {
+  id: number;
+  title: string;
+  category: string;
+  nickname: string;
+  date: string;
+  content: string;
+  answer: string;
+  secret: boolean;
+}
+
+export interface AskDataType {
+  totalElement: number;
+  categoryElement: number[];
+  content: AskDataContentType[];
+}
+
+interface AskContainerProps {
+  askRef: React.RefObject<HTMLDivElement>;
+}
+
+const AskContainer = ({ askRef }: AskContainerProps) => {
+  const { page, sort, setPage, setSort } = useSortPaging(1, "베스트순");
+  const { data } = useSuspenseQuery<AskDataType>(
+    ["Store", "ProductDetal", "Ask", "1", sort, page],
+    `ask?sort=${sort}&page=${page}`,
+  );
+
+  return <Ask page={page} setPage={setPage} sort={sort} setSort={setSort} data={data} askRef={askRef} />;
+};
+
+export default AskContainer;

--- a/src/components/Store/ProductDetail/Detail/Ask/AskList/AskItem/AskItem.stories.tsx
+++ b/src/components/Store/ProductDetail/Detail/Ask/AskList/AskItem/AskItem.stories.tsx
@@ -1,0 +1,39 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import AskItem from "./AskItem";
+
+export default {
+  title: "Store/ProductDetail/Detail/Ask/AskList/AskItem",
+  component: AskItem,
+} as ComponentMeta<typeof AskItem>;
+
+const Template: ComponentStory<typeof AskItem> = args => <AskItem {...args} />;
+
+export const OpenType = Template.bind({});
+OpenType.args = {
+  data: {
+    id: 4,
+    title: "이번달에 살 수 있나요?",
+    category: "기타",
+    nickname: "grenus",
+    date: "2023.01.03",
+    content: "린스바만 계속 기다리는데 재입고 언제될까요?ㅠㅠ 빨리 입고해주세요",
+    answer:
+      "안녕하세요 동구밭 입니다 =] 문의 주신 린스바는 원료 수급이 원활하지 못해 제작 과정에 어려움을 겪고 있었으나, 현재 원료 확보된 상태로 밤낮으로 생산에 힘을 쓰고 있어 6월 중순 입고될 예정입니다ㅜㅜ빠른 입고 될 수 있도록 최대한 노력하겠습니다. 동구밭을 찾아주셔서 감사합니다! 좋은 하루 보내세요 = ]",
+    secret: false,
+  },
+};
+
+export const SecretType = Template.bind({});
+SecretType.args = {
+  data: {
+    id: 4,
+    title: "이번달에 살 수 있나요?",
+    category: "기타",
+    nickname: "grenus",
+    date: "2023.01.03",
+    content: "린스바만 계속 기다리는데 재입고 언제될까요?ㅠㅠ 빨리 입고해주세요",
+    answer:
+      "안녕하세요 동구밭 입니다 =] 문의 주신 린스바는 원료 수급이 원활하지 못해 제작 과정에 어려움을 겪고 있었으나, 현재 원료 확보된 상태로 밤낮으로 생산에 힘을 쓰고 있어 6월 중순 입고될 예정입니다ㅜㅜ빠른 입고 될 수 있도록 최대한 노력하겠습니다. 동구밭을 찾아주셔서 감사합니다! 좋은 하루 보내세요 = ]",
+    secret: true,
+  },
+};

--- a/src/components/Store/ProductDetail/Detail/Ask/AskList/AskItem/AskItem.styles.ts
+++ b/src/components/Store/ProductDetail/Detail/Ask/AskList/AskItem/AskItem.styles.ts
@@ -1,0 +1,77 @@
+import styled from "styled-components";
+
+export const AskItemLayout = styled.div`
+  display: flex;
+  border-bottom: 1px solid #eaeaea;
+  padding: 10px 0;
+`;
+
+export const AskItemOrder = styled.div`
+  font-size: 18px;
+  font-weight: 600;
+  color: gray;
+  margin-right: 30px;
+  padding: 10px 0;
+`;
+
+export const AskItemTypeTitleBox = styled.div`
+  display: flex;
+  gap: 10px;
+  min-width: 400px;
+  flex-grow: 2;
+`;
+
+export const AskItemCategory = styled.div`
+  font-size: 18px;
+  font-weight: 600;
+  padding: 10px 0;
+`;
+
+export const AskItemTitle = styled.div`
+  font-size: 17px;
+  padding: 10px 0;
+`;
+
+export const AskItemUserId = styled.div`
+  display: flex;
+  border-bottom: 1px sold #eaeaea;
+  padding: 10px 0;
+  min-width: 80px;
+`;
+
+export const AskItemDate = styled.div`
+  display: flex;
+  border-bottom: 1px sold #eaeaea;
+  padding: 10px 0;
+`;
+
+export const AskItemDetailBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  background-color: #efefef;
+  padding: 20px 50px;
+`;
+
+export const AskItemDetailSubBox = styled.div`
+  padding: 10px;
+  & + & {
+    border-top: 1px solid #d9d9d9;
+  }
+`;
+
+export const AskItemDetailTitle = styled.div`
+  display: flex;
+  border-bottom: 1px sold #eaeaea;
+  padding: 10px 0;
+  & > i {
+    color: #797979;
+    margin: 0 5px 0 0;
+  }
+`;
+
+export const AskItemDetailContent = styled.div`
+  display: flex;
+  border-bottom: 1px sold #eaeaea;
+  padding: 10px 0;
+  line-height: 1.55;
+`;

--- a/src/components/Store/ProductDetail/Detail/Ask/AskList/AskItem/AskItem.tsx
+++ b/src/components/Store/ProductDetail/Detail/Ask/AskList/AskItem/AskItem.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import { AskDataContentType } from "../../AskContainer";
+import {
+  AskItemCategory,
+  AskItemDate,
+  AskItemDetailBox,
+  AskItemDetailContent,
+  AskItemDetailSubBox,
+  AskItemDetailTitle,
+  AskItemLayout,
+  AskItemOrder,
+  AskItemTitle,
+  AskItemTypeTitleBox,
+  AskItemUserId,
+} from "./AskItem.styles";
+
+interface AskItemProps {
+  data: AskDataContentType;
+}
+
+const AskItem = ({ data }: AskItemProps) => {
+  const [detailOpen, setDetailOpen] = useState(false);
+  return (
+    <>
+      <AskItemLayout
+        onClick={() => {
+          if (!data.secret) setDetailOpen(!detailOpen);
+        }}
+      >
+        <AskItemOrder>{data.id}</AskItemOrder>
+        <AskItemTypeTitleBox>
+          <AskItemCategory>
+            {data.secret && "비밀"}[{data.category}]
+          </AskItemCategory>
+          <AskItemTitle>{data.secret ? "비밀글입니다." : data.title}</AskItemTitle>
+        </AskItemTypeTitleBox>
+        <AskItemUserId>{data.nickname}</AskItemUserId>
+        <AskItemDate>{data.date}</AskItemDate>
+      </AskItemLayout>
+      {detailOpen && (
+        <AskItemDetailBox onClick={() => setDetailOpen(!detailOpen)}>
+          <AskItemDetailSubBox>
+            <AskItemDetailTitle>
+              <i>[{data.category}]</i>
+              {data.title}
+            </AskItemDetailTitle>
+            <AskItemDetailContent>{data.content}</AskItemDetailContent>
+          </AskItemDetailSubBox>
+          <AskItemDetailSubBox>
+            <AskItemDetailTitle>
+              <i>답변</i>
+            </AskItemDetailTitle>
+            <AskItemDetailContent>{data.answer}</AskItemDetailContent>
+          </AskItemDetailSubBox>
+        </AskItemDetailBox>
+      )}
+    </>
+  );
+};
+
+export default AskItem;

--- a/src/components/Store/ProductDetail/Detail/Ask/AskList/AskList.stories.tsx
+++ b/src/components/Store/ProductDetail/Detail/Ask/AskList/AskList.stories.tsx
@@ -1,0 +1,59 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import AskList from "./AskList";
+
+export default {
+  title: "Store/ProductDetail/Detail/Ask/AskList",
+  component: AskList,
+} as ComponentMeta<typeof AskList>;
+
+const Template: ComponentStory<typeof AskList> = args => <AskList {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  data: [
+    {
+      id: 1,
+      title: "이번달에 살 수 있나요?",
+      category: "제품문의",
+      nickname: "grenus",
+      date: "2023.01.03",
+      content: "린스바만 계속 기다리는데 재입고 언제될까요?ㅠㅠ 빨리 입고해주세요",
+      answer:
+        "안녕하세요 동구밭 입니다 =] 문의 주신 린스바는 원료 수급이 원활하지 못해 제작 과정에 어려움을 겪고 있었으나, 현재 원료 확보된 상태로 밤낮으로 생산에 힘을 쓰고 있어 6월 중순 입고될 예정입니다ㅜㅜ빠른 입고 될 수 있도록 최대한 노력하겠습니다. 동구밭을 찾아주셔서 감사합니다! 좋은 하루 보내세요 = ]",
+      secret: true,
+    },
+    {
+      id: 2,
+      title: "이번달에 살 수 있나요?",
+      category: "재입고문의",
+      nickname: "grenus",
+      date: "2023.01.03",
+      content: "린스바만 계속 기다리는데 재입고 언제될까요?ㅠㅠ 빨리 입고해주세요",
+      answer:
+        "안녕하세요 동구밭 입니다 =] 문의 주신 린스바는 원료 수급이 원활하지 못해 제작 과정에 어려움을 겪고 있었으나, 현재 원료 확보된 상태로 밤낮으로 생산에 힘을 쓰고 있어 6월 중순 입고될 예정입니다ㅜㅜ빠른 입고 될 수 있도록 최대한 노력하겠습니다. 동구밭을 찾아주셔서 감사합니다! 좋은 하루 보내세요 = ]",
+      secret: false,
+    },
+    {
+      id: 3,
+      title: "이번달에 살 수 있나요?",
+      category: "배송문의",
+      nickname: "grenus",
+      date: "2023.01.03",
+      content: "린스바만 계속 기다리는데 재입고 언제될까요?ㅠㅠ 빨리 입고해주세요",
+      answer:
+        "안녕하세요 동구밭 입니다 =] 문의 주신 린스바는 원료 수급이 원활하지 못해 제작 과정에 어려움을 겪고 있었으나, 현재 원료 확보된 상태로 밤낮으로 생산에 힘을 쓰고 있어 6월 중순 입고될 예정입니다ㅜㅜ빠른 입고 될 수 있도록 최대한 노력하겠습니다. 동구밭을 찾아주셔서 감사합니다! 좋은 하루 보내세요 = ]",
+      secret: false,
+    },
+    {
+      id: 4,
+      title: "이번달에 살 수 있나요?",
+      category: "기타",
+      nickname: "grenus",
+      date: "2023.01.03",
+      content: "린스바만 계속 기다리는데 재입고 언제될까요?ㅠㅠ 빨리 입고해주세요",
+      answer:
+        "안녕하세요 동구밭 입니다 =] 문의 주신 린스바는 원료 수급이 원활하지 못해 제작 과정에 어려움을 겪고 있었으나, 현재 원료 확보된 상태로 밤낮으로 생산에 힘을 쓰고 있어 6월 중순 입고될 예정입니다ㅜㅜ빠른 입고 될 수 있도록 최대한 노력하겠습니다. 동구밭을 찾아주셔서 감사합니다! 좋은 하루 보내세요 = ]",
+      secret: false,
+    },
+  ],
+};

--- a/src/components/Store/ProductDetail/Detail/Ask/AskList/AskList.styles.ts
+++ b/src/components/Store/ProductDetail/Detail/Ask/AskList/AskList.styles.ts
@@ -1,0 +1,6 @@
+import styled from "styled-components";
+
+export const AskListLayout = styled.div`
+  max-width: 1200px;
+  margin: auto;
+`;

--- a/src/components/Store/ProductDetail/Detail/Ask/AskList/AskList.tsx
+++ b/src/components/Store/ProductDetail/Detail/Ask/AskList/AskList.tsx
@@ -1,0 +1,19 @@
+import { AskDataContentType } from "../AskContainer";
+import AskItem from "./AskItem/AskItem";
+import { AskListLayout } from "./AskList.styles";
+
+interface AskListProps {
+  data: AskDataContentType[];
+}
+
+const AskList = ({ data }: AskListProps) => {
+  return (
+    <AskListLayout>
+      {data.map((el, index) => (
+        <AskItem data={el} key={index} />
+      ))}
+    </AskListLayout>
+  );
+};
+
+export default AskList;

--- a/src/components/Store/ProductDetail/Detail/Ask/CategoryNavigation/CategoryNavigation.stories.tsx
+++ b/src/components/Store/ProductDetail/Detail/Ask/CategoryNavigation/CategoryNavigation.stories.tsx
@@ -1,0 +1,17 @@
+import { action } from "@storybook/addon-actions";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import CategoryNavigation from "./CategoryNavigation";
+
+export default {
+  title: "Store/ProductDetail/Detail/Ask/CategoryNavigation",
+  component: CategoryNavigation,
+} as ComponentMeta<typeof CategoryNavigation>;
+
+const Template: ComponentStory<typeof CategoryNavigation> = args => <CategoryNavigation {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  sort: "전체(156)",
+  setSort: action("정렬변경"),
+  counts: [156, 106, 10, 30, 10],
+};

--- a/src/components/Store/ProductDetail/Detail/Ask/CategoryNavigation/CategoryNavigation.styles.ts
+++ b/src/components/Store/ProductDetail/Detail/Ask/CategoryNavigation/CategoryNavigation.styles.ts
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+export const CategoryNavigationLayout = styled.ul`
+  display: flex;
+  gap: 10px;
+  margin-left: auto;
+`;
+
+export const CategoryNavigationItem = styled.li<{ selected: boolean }>`
+  font-weight: ${props => (props.selected ? "600" : "400")};
+`;

--- a/src/components/Store/ProductDetail/Detail/Ask/CategoryNavigation/CategoryNavigation.tsx
+++ b/src/components/Store/ProductDetail/Detail/Ask/CategoryNavigation/CategoryNavigation.tsx
@@ -1,0 +1,26 @@
+import { CategoryNavigationItem, CategoryNavigationLayout } from "./CategoryNavigation.styles";
+
+interface CategoryNavigationProps {
+  sort: string;
+  setSort: React.Dispatch<React.SetStateAction<string>>;
+  counts: number[];
+}
+
+const CategoryNavigation = ({ sort, setSort, counts }: CategoryNavigationProps) => {
+  return (
+    <CategoryNavigationLayout>
+      {[
+        `전체(${counts[0]})`,
+        `제품문의(${counts[1]})`,
+        `재입고문의(${counts[2]})`,
+        `배송문의(${counts[3]})`,
+        `기타(${counts[4]})`,
+      ].map(el => (
+        <CategoryNavigationItem key={el} selected={sort === el} onClick={() => setSort(el)}>
+          {el}
+        </CategoryNavigationItem>
+      ))}
+    </CategoryNavigationLayout>
+  );
+};
+export default CategoryNavigation;

--- a/src/components/Store/ProductDetail/Detail/Delivery/Delivery.stories.tsx
+++ b/src/components/Store/ProductDetail/Detail/Delivery/Delivery.stories.tsx
@@ -1,0 +1,21 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import Delivery from "./Delivery";
+
+export default {
+  title: "Store/ProductDetail/Detail/Delivery",
+  component: Delivery,
+} as ComponentMeta<typeof Delivery>;
+
+const Template: ComponentStory<typeof Delivery> = args => <Delivery {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  data: {
+    delivery: ["일반택배", "3000원 (50,000원 이상 무료배송)", "3000원", "배송불가 지역이 없습니다."],
+    return: [
+      "3000원 (최초 배송비가 무료인 경우 6000원 부과)",
+      "6000원",
+      "(12345) 서울 송파구 도로명주소 55길 33 1층 그리너스",
+    ],
+  },
+};

--- a/src/components/Store/ProductDetail/Detail/Delivery/Delivery.styles.ts
+++ b/src/components/Store/ProductDetail/Detail/Delivery/Delivery.styles.ts
@@ -1,0 +1,55 @@
+import styled from "styled-components";
+
+export const DeliveryLayout = styled.div`
+  width: 100%;
+  padding: 100px 0 0 0;
+`;
+
+export const DeliveryCol = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 50px;
+  max-width: 1200px;
+  margin: auto;
+`;
+
+export const DeliveryBox = styled.div``;
+
+export const DeliveryTitle = styled.h3`
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0 0 15px 0;
+`;
+
+export const DeliveryRow = styled.div`
+  border-bottom: 1px solid #eaeaea;
+  padding: 10px 0;
+  display: flex;
+`;
+
+export const DeliverySubTitle = styled.div`
+  font-size: 16px;
+  font-weight: 400;
+  color: gray;
+  width: 300px;
+`;
+
+export const DeliveryText = styled.div``;
+
+export const DeliveryAlertText = styled.div`
+  color: #979797;
+  margin: 0 0 10px 0;
+`;
+
+export const DeliveryOrderList = styled.ol`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+export const DeliveryItem = styled.li`
+  & > i {
+    font-weight: 600;
+    margin: 0 20px 0 0;
+  }
+`;

--- a/src/components/Store/ProductDetail/Detail/Delivery/Delivery.tsx
+++ b/src/components/Store/ProductDetail/Detail/Delivery/Delivery.tsx
@@ -1,0 +1,84 @@
+import {
+  DeliveryAlertText,
+  DeliveryBox,
+  DeliveryCol,
+  DeliveryItem,
+  DeliveryLayout,
+  DeliveryOrderList,
+  DeliveryRow,
+  DeliverySubTitle,
+  DeliveryText,
+  DeliveryTitle,
+} from "./Delivery.styles";
+import { DeliveryDataType } from "./DeliveryContainer";
+
+interface DeliveryProps {
+  data: DeliveryDataType;
+  deliveryRef: React.RefObject<HTMLDivElement>;
+}
+
+const Delivery = ({ data, deliveryRef }: DeliveryProps) => {
+  return (
+    <DeliveryLayout ref={deliveryRef}>
+      <DeliveryCol>
+        <DeliveryBox>
+          <DeliveryTitle>배송</DeliveryTitle>
+          {["택배배송", "배송비", "도서산간 추가 배송비", "배송불가 지역"].map((el, index) => (
+            <DeliveryRow key={el}>
+              <DeliverySubTitle>{el}</DeliverySubTitle>
+              <DeliveryText>{data.delivery[index]}</DeliveryText>
+            </DeliveryRow>
+          ))}
+        </DeliveryBox>
+        <DeliveryBox>
+          <DeliveryTitle>교환/환불</DeliveryTitle>
+          {["반품배송비", "교환배송비", "보내실 곳"].map((el, index) => (
+            <DeliveryRow key={el}>
+              <DeliverySubTitle>{el}</DeliverySubTitle>
+              <DeliveryText>{data.return[index]}</DeliveryText>
+            </DeliveryRow>
+          ))}
+        </DeliveryBox>
+        <DeliveryBox>
+          <DeliveryTitle>반품/교환 사유에 따른 요청 가능 기간</DeliveryTitle>
+          <DeliveryAlertText>
+            반품 시 먼저 판매자와 연락하셔서 반품사유, 택배사, 배송비, 반품지 주소 등을 협의하신 후 반품상품을 발송해
+            주시기 바랍니다.
+          </DeliveryAlertText>
+          <DeliveryOrderList>
+            <DeliveryItem>
+              <i>1</i>구매자 단순 변심은 상품 수령 후 7일 이내
+            </DeliveryItem>
+            <DeliveryItem>
+              <i>2</i>표시/광고와 상이, 상품하자의 경우 상품 수령 후 3개월 이내 혹은 표시/광고와 다른 사실을 안 날로부터
+              30일 이내.
+            </DeliveryItem>
+            <DeliveryItem>
+              <i>3</i>둘 중 하나 경과 시 반품/교환 불가
+            </DeliveryItem>
+          </DeliveryOrderList>
+        </DeliveryBox>
+        <DeliveryBox>
+          <DeliveryTitle>반품/교환 불가능 사유</DeliveryTitle>
+          <DeliveryAlertText>아래와 같은 경우 반품/교환이 불가능합니다.</DeliveryAlertText>
+          <DeliveryOrderList>
+            <DeliveryItem>
+              <i>1</i>반품요청기간이 지난 경우
+            </DeliveryItem>
+            <DeliveryItem>
+              <i>2</i>구매자의 책임 있는 사유로 상품 등이 멸실 또는 훼손된 경우
+            </DeliveryItem>
+            <DeliveryItem>
+              <i>3</i>포장을 개봉하였으나 포장이 훼손되어 상품가치가 현저히 상실된 경우
+            </DeliveryItem>
+            <DeliveryItem>
+              <i>4</i>고객주문 확인 후 상품제작에 들어가는 주문제작상품
+            </DeliveryItem>
+          </DeliveryOrderList>
+        </DeliveryBox>
+      </DeliveryCol>
+    </DeliveryLayout>
+  );
+};
+
+export default Delivery;

--- a/src/components/Store/ProductDetail/Detail/Delivery/DeliveryContainer.tsx
+++ b/src/components/Store/ProductDetail/Detail/Delivery/DeliveryContainer.tsx
@@ -1,0 +1,19 @@
+import useSuspenseQuery from "../../../../../hooks/useSuspenseQuery";
+import Delivery from "./Delivery";
+
+export interface DeliveryDataType {
+  delivery: string[];
+  return: string[];
+}
+
+interface DeliveryContainerProps {
+  deliveryRef: React.RefObject<HTMLDivElement>;
+}
+
+const DeliveryContainer = ({ deliveryRef }: DeliveryContainerProps) => {
+  const { data } = useSuspenseQuery<DeliveryDataType>(["Store", "ProductDetail", "Delivery", "1"], "delivery");
+
+  return <Delivery data={data} deliveryRef={deliveryRef} />;
+};
+
+export default DeliveryContainer;

--- a/src/components/Store/ProductDetail/Detail/Detail.styles.ts
+++ b/src/components/Store/ProductDetail/Detail/Detail.styles.ts
@@ -1,0 +1,3 @@
+import styled from "styled-components";
+
+export const DetailLayout = styled.div``;

--- a/src/components/Store/ProductDetail/Detail/Detail.tsx
+++ b/src/components/Store/ProductDetail/Detail/Detail.tsx
@@ -1,0 +1,52 @@
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import AskContainer from "./Ask/AskContainer";
+import DeliveryContainer from "./Delivery/DeliveryContainer";
+import { DetailLayout } from "./Detail.styles";
+import InfoContainer from "./Info/InfoContainer";
+import InfoNavigationContainer from "./InfoNavigation/InfoNavigationContainer";
+import RecommendContainer from "./Recommend/RecommendContainer";
+import ReviewContainer from "./Review/ReviewContainer";
+
+interface DetailProps {
+  refs: {
+    [index: string]: React.RefObject<HTMLDivElement>;
+  };
+  navigate: (type: string) => void;
+  navigation: string;
+}
+
+const Detail = ({ refs, navigate, navigation }: DetailProps) => {
+  return (
+    <DetailLayout>
+      <ErrorBoundary FallbackComponent={() => <div>...에러발생</div>}>
+        <Suspense fallback={<div>...로딩중</div>}>
+          <InfoNavigationContainer navigate={navigate} navigation={navigation} />
+          <InfoContainer infoRef={refs.info} />
+        </Suspense>
+      </ErrorBoundary>
+      <ErrorBoundary FallbackComponent={() => <div>...에러발생</div>}>
+        <Suspense fallback={<div>...로딩중</div>}>
+          <ReviewContainer reviewRef={refs.review} />
+        </Suspense>
+      </ErrorBoundary>
+      <ErrorBoundary FallbackComponent={() => <div>...에러발생</div>}>
+        <Suspense fallback={<div>...로딩중</div>}>
+          <DeliveryContainer deliveryRef={refs.delivery} />
+        </Suspense>
+      </ErrorBoundary>
+      <ErrorBoundary FallbackComponent={() => <div>...에러발생</div>}>
+        <Suspense fallback={<div>...로딩중</div>}>
+          <AskContainer askRef={refs.ask} />
+        </Suspense>
+      </ErrorBoundary>
+      <ErrorBoundary FallbackComponent={() => <div>...에러발생</div>}>
+        <Suspense fallback={<div>...로딩중</div>}>
+          <RecommendContainer recommendRef={refs.recommend} />
+        </Suspense>
+      </ErrorBoundary>
+    </DetailLayout>
+  );
+};
+
+export default Detail;

--- a/src/components/Store/ProductDetail/Detail/DetailContainer.tsx
+++ b/src/components/Store/ProductDetail/Detail/DetailContainer.tsx
@@ -1,0 +1,10 @@
+import Detail from "./Detail";
+import useDetail from "./DetailHook";
+
+const DetailContainer = () => {
+  const { refs, navigate, navigation } = useDetail();
+
+  return <Detail refs={refs} navigation={navigation} navigate={navigate} />;
+};
+
+export default DetailContainer;

--- a/src/components/Store/ProductDetail/Detail/DetailHook.ts
+++ b/src/components/Store/ProductDetail/Detail/DetailHook.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef, useState } from "react";
+
+const useDetail = () => {
+  const [navigation, setNavigation] = useState("info");
+  const infoRef = useRef<HTMLDivElement>(null);
+  const reviewRef = useRef<HTMLDivElement>(null);
+  const deliveryRef = useRef<HTMLDivElement>(null);
+  const askRef = useRef<HTMLDivElement>(null);
+  const recommendRef = useRef<HTMLDivElement>(null);
+  const refs: { [index: string]: React.RefObject<HTMLDivElement> } = {
+    info: infoRef,
+    review: reviewRef,
+    delivery: deliveryRef,
+    ask: askRef,
+    recommend: recommendRef,
+  };
+  useEffect(() => {
+    let timer = true;
+    const navigatePosition = () => {
+      if (timer) {
+        const curNavigation = Object.keys(refs)
+          .map(ref => ({ position: refs[ref].current?.getBoundingClientRect().top, category: ref }))
+          .reverse()
+          .find(el => (el.position as number) <= 0);
+        if (curNavigation !== undefined) {
+          setNavigation(curNavigation.category);
+        }
+        timer = false;
+      }
+    };
+    const setTimer = setInterval(() => {
+      timer = true;
+    }, 100);
+    window.addEventListener("scroll", navigatePosition);
+    return () => {
+      clearInterval(setTimer);
+      window.removeEventListener("scroll", navigatePosition);
+    };
+  }, []);
+
+  const navigate = (type: string) => {
+    refs[type].current?.scrollIntoView({ behavior: "smooth" });
+    setNavigation(type);
+  };
+
+  return { navigation, refs, navigate };
+};
+
+export default useDetail;

--- a/src/components/Store/ProductDetail/Detail/Info/Info.stories.tsx
+++ b/src/components/Store/ProductDetail/Detail/Info/Info.stories.tsx
@@ -1,0 +1,18 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import Info from "./Info";
+
+export default {
+  title: "Store/ProductDetail/Detail/Info",
+  component: Info,
+} as ComponentMeta<typeof Info>;
+
+const Template: ComponentStory<typeof Info> = args => <Info {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  data: [
+    "http://localhost:8000/images/test1.jpg",
+    "http://localhost:8000/images/test2.jpg",
+    "http://localhost:8000/images/test3.jpg",
+  ],
+};

--- a/src/components/Store/ProductDetail/Detail/Info/Info.styles.ts
+++ b/src/components/Store/ProductDetail/Detail/Info/Info.styles.ts
@@ -1,0 +1,41 @@
+import styled from "styled-components";
+
+export const InfoLayout = styled.div`
+  width: 100%;
+  padding: 100px 0 0 0;
+`;
+
+export const InfoTitle = styled.div`
+  font-weight: 600;
+  margin: 0 0 10px 0;
+`;
+
+export const InfoCol = styled.div`
+  max-width: 1200px;
+  margin: auto;
+`;
+
+export const InfoImg = styled.img`
+  position: relative;
+  height: 1000px;
+  width: 100%;
+  object-fit: cover;
+  background-color: #eaeaea;
+  &:after {
+    content: "";
+    position: absolute;
+    display: block;
+    width: 100%;
+    height: 50%;
+    top: 50%;
+    background: linear-gradient(to top, white, white 10%, transparent);
+  }
+`;
+
+export const InfoButton = styled.div`
+  height: 60px;
+  border: 1px solid black;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/src/components/Store/ProductDetail/Detail/Info/Info.tsx
+++ b/src/components/Store/ProductDetail/Detail/Info/Info.tsx
@@ -1,0 +1,25 @@
+import { useState } from "react";
+import { InfoButton, InfoCol, InfoImg, InfoLayout, InfoTitle } from "./Info.styles";
+import { InfoDataType } from "./InfoContainer";
+
+interface InfoProps {
+  infoRef: React.RefObject<HTMLDivElement>;
+  data: InfoDataType;
+}
+
+const Info = ({ data, infoRef }: InfoProps) => {
+  const [fold, setFold] = useState(true);
+  return (
+    <InfoLayout ref={infoRef}>
+      <InfoCol>
+        <InfoTitle>상품정보</InfoTitle>
+        {(fold ? [data[0]] : data).map(src => (
+          <InfoImg src={src} key={src} />
+        ))}
+        <InfoButton onClick={() => setFold(!fold)}>상품정보 {fold ? "더보기" : "접기"}</InfoButton>
+      </InfoCol>
+    </InfoLayout>
+  );
+};
+
+export default Info;

--- a/src/components/Store/ProductDetail/Detail/Info/InfoContainer.tsx
+++ b/src/components/Store/ProductDetail/Detail/Info/InfoContainer.tsx
@@ -1,0 +1,16 @@
+import useSuspenseQuery from "../../../../../hooks/useSuspenseQuery";
+import Info from "./Info";
+
+export type InfoDataType = string[];
+
+interface InfoContainerProps {
+  infoRef: React.RefObject<HTMLDivElement>;
+}
+
+const InfoContainer = ({ infoRef }: InfoContainerProps) => {
+  const { data } = useSuspenseQuery<InfoDataType>(["Store", "ProductDetail", "Info", "1"], "info");
+
+  return <Info data={data} infoRef={infoRef} />;
+};
+
+export default InfoContainer;

--- a/src/components/Store/ProductDetail/Detail/InfoNavigation/InfoNavigation.styles.ts
+++ b/src/components/Store/ProductDetail/Detail/InfoNavigation/InfoNavigation.styles.ts
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+
+export const InfoNavigationLayout = styled.div`
+  width: 100%;
+  margin: 50px 0 0 0;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background-color: #f1f1f1;
+`;
+
+export const InfoNavigationRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  max-width: 1160px;
+  gap: 40px;
+  margin: auto;
+  padding: 0 20px;
+`;
+
+export const InfoNavigationItem = styled.a<{ selected: boolean }>`
+  padding: 20px 60px;
+  border-bottom: ${props => (props.selected ? "2px solid black" : "none")};
+`;

--- a/src/components/Store/ProductDetail/Detail/InfoNavigation/InfoNavigation.tsx
+++ b/src/components/Store/ProductDetail/Detail/InfoNavigation/InfoNavigation.tsx
@@ -1,0 +1,31 @@
+import { InfoNavigationItem, InfoNavigationLayout, InfoNavigationRow } from "./InfoNavigation.styles";
+
+interface InfoNavigationProps {
+  data: { review: string; ask: string };
+  navigate: (type: string) => void;
+  navigation: string;
+}
+
+const InfoNavigation = ({ data, navigate, navigation }: InfoNavigationProps) => {
+  return (
+    <InfoNavigationLayout>
+      <InfoNavigationRow>
+        {[
+          { ko: "상품정보", en: "info" },
+          { ko: `리뷰${data.review}`, en: "review" },
+          { ko: "배송/환불", en: "delivery" },
+          { ko: `문의${data.ask}`, en: "ask" },
+          { ko: "추천제품", en: "recommend" },
+        ].map(el => {
+          return (
+            <InfoNavigationItem key={el.en} onClick={() => navigate(el.en)} selected={navigation === el.en}>
+              {el.ko}
+            </InfoNavigationItem>
+          );
+        })}
+      </InfoNavigationRow>
+    </InfoNavigationLayout>
+  );
+};
+
+export default InfoNavigation;

--- a/src/components/Store/ProductDetail/Detail/InfoNavigation/InfoNavigationContainer.tsx
+++ b/src/components/Store/ProductDetail/Detail/InfoNavigation/InfoNavigationContainer.tsx
@@ -1,0 +1,23 @@
+import axios from "axios";
+import { useQuery } from "react-query";
+import InfoNavigation from "./InfoNavigation";
+
+interface InfoNavigationContainerProps {
+  navigate: (type: string) => void;
+  navigation: string;
+}
+
+const InfoNavigationContainer = ({ navigate, navigation }: InfoNavigationContainerProps) => {
+  const { data } = useQuery(
+    ["product", "infonavigation", "1"],
+    () => axios(`http://localhost:8000/infonavigation`).then(res => res.data),
+    {
+      suspense: true,
+      useErrorBoundary: true,
+    },
+  );
+
+  return <InfoNavigation data={data} navigate={navigate} navigation={navigation} />;
+};
+
+export default InfoNavigationContainer;

--- a/src/components/Store/ProductDetail/Detail/Recommend/Recommend.stories.tsx
+++ b/src/components/Store/ProductDetail/Detail/Recommend/Recommend.stories.tsx
@@ -1,0 +1,11 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import Recommend from "./Recommend";
+
+export default {
+  title: "Store/ProductDetail/Detail/Recommend",
+  component: Recommend,
+} as ComponentMeta<typeof Recommend>;
+
+const Template: ComponentStory<typeof Recommend> = () => <Recommend />;
+
+export const GeneralType = Template.bind({});

--- a/src/components/Store/ProductDetail/Detail/Recommend/Recommend.styles.ts
+++ b/src/components/Store/ProductDetail/Detail/Recommend/Recommend.styles.ts
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+
+export const RecommendLayout = styled.div`
+  width: 100%;
+  padding: 100px 0;
+`;
+
+export const RecommendTitle = styled.div`
+  max-width: 1200px;
+  margin: 0 auto 20px auto;
+  font-weight: 600;
+  padding: 0 0 10px 0;
+  border-bottom: 1px solid #eaeaea;
+`;
+export const RecommendList = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  gap: 10px;
+  max-width: 1200px;
+  margin: auto;
+`;

--- a/src/components/Store/ProductDetail/Detail/Recommend/Recommend.tsx
+++ b/src/components/Store/ProductDetail/Detail/Recommend/Recommend.tsx
@@ -1,0 +1,26 @@
+import { AxiosResponse } from "axios";
+import { UseMutateFunction } from "react-query";
+import ProductCard from "../../../Common/ProductCard/ProductCard";
+import { RecommendLayout, RecommendList, RecommendTitle } from "./Recommend.styles";
+import { RecommendDataType } from "./RecommendContainer";
+
+interface RecommendProps {
+  data: RecommendDataType;
+  recommendRef: React.RefObject<HTMLDivElement>;
+  changeLiked: UseMutateFunction<AxiosResponse<unknown, unknown>, unknown, unknown, unknown>;
+}
+
+const Recommend = ({ data, recommendRef, changeLiked }: RecommendProps) => {
+  return (
+    <RecommendLayout ref={recommendRef}>
+      <RecommendTitle>이런 제품은 어떠세요?</RecommendTitle>
+      <RecommendList>
+        {data.map((card, index) => {
+          return <ProductCard {...card} key={index} changeLiked={changeLiked}></ProductCard>;
+        })}
+      </RecommendList>
+    </RecommendLayout>
+  );
+};
+
+export default Recommend;

--- a/src/components/Store/ProductDetail/Detail/Recommend/RecommendContainer.tsx
+++ b/src/components/Store/ProductDetail/Detail/Recommend/RecommendContainer.tsx
@@ -1,0 +1,46 @@
+import axios from "axios";
+import useSetQueryMutate from "../../../../../hooks/useSetQueryMutate";
+import useSuspenseQuery from "../../../../../hooks/useSuspenseQuery";
+import { ProductCardProps } from "../../../Common/ProductCard/ProductCard";
+import Recommend from "./Recommend";
+
+export type RecommendDataType = {
+  id: number;
+  category: string;
+  brand: string;
+  title: string;
+  discountRate: string;
+  price: string;
+  badges: string[];
+  liked: boolean;
+}[];
+
+interface RecommendContainerProps {
+  recommendRef: React.RefObject<HTMLDivElement>;
+}
+
+const a = () => {
+  return ["a"];
+};
+
+const RecommendContainer = ({ recommendRef }: RecommendContainerProps) => {
+  const { data } = useSuspenseQuery<RecommendDataType>(["Store", "ProductDetail", "Recommend", "1"], "recommend");
+  const { mutate } = useSetQueryMutate<{ id: number }, (data: ProductCardProps[]) => ProductCardProps[]>(
+    id => axios.post("http://localhost:8000/product", { id }),
+    ["Store", "ProductDetail", "Recommend", "1"],
+    e => {
+      return (data: ProductCardProps[]) => {
+        return data.map(el => {
+          if (el.id === e.data.id) {
+            console.log(el.id);
+            return { ...el, liked: !el.liked };
+          }
+          return el;
+        });
+      };
+    },
+  );
+  return <Recommend data={data} recommendRef={recommendRef} changeLiked={mutate} />;
+};
+
+export default RecommendContainer;

--- a/src/components/Store/ProductDetail/Detail/Review/Review.stories.tsx
+++ b/src/components/Store/ProductDetail/Detail/Review/Review.stories.tsx
@@ -1,0 +1,96 @@
+import { action } from "@storybook/addon-actions";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import Review from "./Review";
+
+export default {
+  title: "Store/ProductDetail/Detail/Review",
+  component: Review,
+} as ComponentMeta<typeof Review>;
+
+const Template: ComponentStory<typeof Review> = args => <Review {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  page: 1,
+  setPage: action("페이지이동"),
+  sort: "베스트순",
+  setSort: action("정렬변경"),
+  data: {
+    avgrate: 3.6,
+    rates: [1000, 200, 30, 3, 1],
+    total: 1234,
+    content: [
+      {
+        avatar: "http://localhost:8000/images/test1.jpg",
+        nickname: "그린어스",
+        rate: 5,
+        date: "2023.01.03",
+        liked: true,
+        likedCount: 10,
+        content:
+          "거품도 잘 나고 배송도 빠르네요! 아주 만족합니다. 거품도 잘 나고 배송도 빠르네요! 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑",
+        photo: [
+          "http://localhost:8000/images/test1.jpg",
+          "http://localhost:8000/images/test2.jpg",
+          "http://localhost:8000/images/test3.jpg",
+        ],
+      },
+      {
+        avatar: "http://localhost:8000/images/test1.jpg",
+        nickname: "그린어스",
+        rate: 1,
+        date: "2023.01.03",
+        liked: true,
+        likedCount: 10,
+        content:
+          "거품도 잘 나고 배송도 빠르네요! 아주 만족합니다. 거품도 잘 나고 배송도 빠르네요! 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑",
+        photo: [
+          "http://localhost:8000/images/test1.jpg",
+          "http://localhost:8000/images/test2.jpg",
+          "http://localhost:8000/images/test3.jpg",
+        ],
+      },
+      {
+        avatar: "http://localhost:8000/images/test1.jpg",
+        nickname: "그린어스",
+        rate: 2,
+        date: "2023.01.03",
+        liked: true,
+        likedCount: 10,
+        content:
+          "거품도 잘 나고 배송도 빠르네요! 아주 만족합니다. 거품도 잘 나고 배송도 빠르네요! 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑",
+        photo: [
+          "http://localhost:8000/images/test1.jpg",
+          "http://localhost:8000/images/test2.jpg",
+          "http://localhost:8000/images/test3.jpg",
+        ],
+      },
+      {
+        avatar: "http://localhost:8000/images/test1.jpg",
+        nickname: "그린어스",
+        rate: 5,
+        date: "2023.01.03",
+        liked: true,
+        likedCount: 10,
+        content:
+          "거품도 잘 나고 배송도 빠르네요! 아주 만족합니다. 거품도 잘 나고 배송도 빠르네요! 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑",
+        photo: [],
+      },
+      {
+        avatar: "http://localhost:8000/images/test1.jpg",
+        nickname: "그린어스",
+        rate: 3,
+        date: "2023.01.03",
+        liked: true,
+        likedCount: 10,
+        content:
+          "거품도 잘 나고 배송도 빠르네요! 아주 만족합니다. 거품도 잘 나고 배송도 빠르네요! 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑",
+        photo: [
+          "http://localhost:8000/images/test1.jpg",
+          "http://localhost:8000/images/test2.jpg",
+          "http://localhost:8000/images/test3.jpg",
+        ],
+      },
+    ],
+  },
+};

--- a/src/components/Store/ProductDetail/Detail/Review/Review.styles.ts
+++ b/src/components/Store/ProductDetail/Detail/Review/Review.styles.ts
@@ -1,0 +1,20 @@
+import styled from "styled-components";
+
+export const ReviewLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: 100px 0 0 0;
+`;
+
+export const ReviewCol = styled.div`
+  margin: auto;
+  max-width: 1200px;
+`;
+
+export const ReviewTitle = styled.div`
+  font-weight: 600;
+  border-bottom: 1px solid #eaeaea;
+  padding: 0 0 5px 0;
+  margin: 0 0 20px 0;
+`;

--- a/src/components/Store/ProductDetail/Detail/Review/Review.tsx
+++ b/src/components/Store/ProductDetail/Detail/Review/Review.tsx
@@ -1,0 +1,31 @@
+import Pagenation from "../../../../Common/Pagenation/Pagenation";
+import { ReviewCol, ReviewLayout, ReviewTitle } from "./Review.styles";
+import { ReviewDataType } from "./ReviewContainer";
+import ReviewList from "./ReviewList/ReviewList";
+import ReviewSort from "./ReviewSort/ReviewSort";
+import Status from "./Status/Status";
+
+interface ReviewProps {
+  page: number;
+  setPage: React.Dispatch<React.SetStateAction<number>>;
+  sort: string;
+  setSort: React.Dispatch<React.SetStateAction<string>>;
+  reviewRef: React.RefObject<HTMLDivElement>;
+  data: ReviewDataType;
+}
+
+const Review = ({ data: { avgrate, rates, content, total }, sort, setSort, page, setPage, reviewRef }: ReviewProps) => {
+  return (
+    <ReviewLayout ref={reviewRef}>
+      <ReviewCol>
+        <ReviewTitle>리뷰({total})</ReviewTitle>
+        <Status avgrate={avgrate} rates={rates} total={total}></Status>
+        <ReviewSort sort={sort} setSort={setSort} />
+        <ReviewList data={content}></ReviewList>
+        <Pagenation curpage={page} pagelist={[1, 2, 3, 4, 5]} movePage={setPage} />
+      </ReviewCol>
+    </ReviewLayout>
+  );
+};
+
+export default Review;

--- a/src/components/Store/ProductDetail/Detail/Review/ReviewContainer.tsx
+++ b/src/components/Store/ProductDetail/Detail/Review/ReviewContainer.tsx
@@ -1,0 +1,36 @@
+import useSortPaging from "../../../../../hooks/useSortPaging";
+import useSuspenseQuery from "../../../../../hooks/useSuspenseQuery";
+import Review from "./Review";
+
+export interface ReviewDataContentType {
+  avatar: string;
+  nickname: string;
+  rate: number;
+  date: string;
+  liked: boolean;
+  likedCount: number;
+  content: string;
+  photo: string[];
+}
+
+export interface ReviewDataType {
+  avgrate: number;
+  rates: number[];
+  total: number;
+  content: ReviewDataContentType[];
+}
+
+interface ReviewContainerProps {
+  reviewRef: React.RefObject<HTMLDivElement>;
+}
+
+const ReviewContainer = ({ reviewRef }: ReviewContainerProps) => {
+  const { page, sort, setPage, setSort } = useSortPaging(1, "베스트순");
+  const { data } = useSuspenseQuery<ReviewDataType>(
+    ["Store", "ProductDetal", "Review", "1", sort, page],
+    `review?sort=${sort}&page=${page}`,
+  );
+  return <Review data={data} sort={sort} page={page} setSort={setSort} setPage={setPage} reviewRef={reviewRef} />;
+};
+
+export default ReviewContainer;

--- a/src/components/Store/ProductDetail/Detail/Review/ReviewList/ReviewItem/ReviewItem.stories.tsx
+++ b/src/components/Store/ProductDetail/Detail/Review/ReviewList/ReviewItem/ReviewItem.stories.tsx
@@ -1,0 +1,28 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import ReviewItem from "./ReviewItem";
+
+export default {
+  title: "Store/ProductDetail/Detail/Review/ReviewItem",
+  component: ReviewItem,
+} as ComponentMeta<typeof ReviewItem>;
+
+const Template: ComponentStory<typeof ReviewItem> = args => <ReviewItem {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  review: {
+    avatar: "http://localhost:8000/images/test1.jpg",
+    nickname: "그린어스",
+    rate: 5,
+    date: "2023.01.03",
+    liked: true,
+    likedCount: 10,
+    content:
+      "거품도 잘 나고 배송도 빠르네요! 아주 만족합니다. 거품도 잘 나고 배송도 빠르네요! 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑",
+    photo: [
+      "http://localhost:8000/images/test1.jpg",
+      "http://localhost:8000/images/test2.jpg",
+      "http://localhost:8000/images/test3.jpg",
+    ],
+  },
+};

--- a/src/components/Store/ProductDetail/Detail/Review/ReviewList/ReviewItem/ReviewItem.styles.ts
+++ b/src/components/Store/ProductDetail/Detail/Review/ReviewList/ReviewItem/ReviewItem.styles.ts
@@ -1,0 +1,83 @@
+import styled from "styled-components";
+
+export const ReviewItemLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 20px 0;
+  border-bottom: 1px solid #eaeaea;
+`;
+
+export const ReviewItemTopBox = styled.div`
+  display: flex;
+  gap: 10px;
+`;
+
+export const ReviewItemUserAvatar = styled.img`
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background-color: #eaeaea;
+`;
+
+export const ReviewItemTopLeftBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+`;
+
+export const ReviewItemUserNickname = styled.div`
+  font-weight: 600;
+`;
+
+export const ReviewItemTopLeftBottomBox = styled.div`
+  display: flex;
+  gap: 10px;
+`;
+
+export const ReviewItemRate = styled.div``;
+
+export const ReviewItemDate = styled.div``;
+
+export const ReviewItemTopRightBox = styled.div`
+  display: flex;
+  margin-left: auto;
+  align-items: center;
+  gap: 10px;
+`;
+
+export const ReviewItemLikeButton = styled.button<{ selected: boolean }>`
+  border-radius: 10px;
+  padding: 7px 10px;
+  border: 1px solid #797979;
+  background-color: ${props => (props.selected ? "#797979" : "white")};
+  color: ${props => (props.selected ? "white" : "black")};
+`;
+
+export const ReviewItemLikeCount = styled.div`
+  & > i {
+    font-weight: 600;
+  }
+`;
+
+export const ReviewItemContent = styled.div`
+  padding: 0 0 0 50px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.6;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+`;
+
+export const ReviewItemImgList = styled.div`
+  padding: 0 0 0 50px;
+  display: flex;
+  gap: 10px;
+`;
+
+export const ReviewItemImg = styled.img`
+  width: 100px;
+  height: 100px;
+  background-color: #eaeaea;
+`;

--- a/src/components/Store/ProductDetail/Detail/Review/ReviewList/ReviewItem/ReviewItem.tsx
+++ b/src/components/Store/ProductDetail/Detail/Review/ReviewList/ReviewItem/ReviewItem.tsx
@@ -1,0 +1,52 @@
+import { ReviewDataContentType } from "../../ReviewContainer";
+import {
+  ReviewItemContent,
+  ReviewItemDate,
+  ReviewItemImg,
+  ReviewItemImgList,
+  ReviewItemLayout,
+  ReviewItemLikeButton,
+  ReviewItemLikeCount,
+  ReviewItemRate,
+  ReviewItemTopBox,
+  ReviewItemTopLeftBottomBox,
+  ReviewItemTopLeftBox,
+  ReviewItemTopRightBox,
+  ReviewItemUserAvatar,
+  ReviewItemUserNickname,
+} from "./ReviewItem.styles";
+
+interface ReviewItemProps {
+  review: ReviewDataContentType;
+}
+
+const ReviewItem = ({ review }: ReviewItemProps) => {
+  return (
+    <ReviewItemLayout>
+      <ReviewItemTopBox>
+        <ReviewItemUserAvatar src={review.avatar} />
+        <ReviewItemTopLeftBox>
+          <ReviewItemUserNickname>{review.nickname}</ReviewItemUserNickname>
+          <ReviewItemTopLeftBottomBox>
+            <ReviewItemRate>별점 {review.rate}점</ReviewItemRate>
+            <ReviewItemDate>{review.date}</ReviewItemDate>
+          </ReviewItemTopLeftBottomBox>
+        </ReviewItemTopLeftBox>
+        <ReviewItemTopRightBox>
+          <ReviewItemLikeButton selected={review.liked}>도움이 돼요</ReviewItemLikeButton>
+          <ReviewItemLikeCount>
+            <i>{review.likedCount}명</i>에게 도움이되었습니다
+          </ReviewItemLikeCount>
+        </ReviewItemTopRightBox>
+      </ReviewItemTopBox>
+      <ReviewItemContent>{review.content}</ReviewItemContent>
+      <ReviewItemImgList>
+        {review.photo.map(src => {
+          return <ReviewItemImg src={src} key={src} />;
+        })}
+      </ReviewItemImgList>
+    </ReviewItemLayout>
+  );
+};
+
+export default ReviewItem;

--- a/src/components/Store/ProductDetail/Detail/Review/ReviewList/ReviewList.stories.tsx
+++ b/src/components/Store/ProductDetail/Detail/Review/ReviewList/ReviewList.stories.tsx
@@ -1,0 +1,86 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import ReviewList from "./ReviewList";
+
+export default {
+  title: "Store/ProductDetail/Detail/Review/ReviewList",
+  component: ReviewList,
+} as ComponentMeta<typeof ReviewList>;
+
+const Template: ComponentStory<typeof ReviewList> = args => <ReviewList {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  data: [
+    {
+      avatar: "http://localhost:8000/images/test1.jpg",
+      nickname: "그린어스",
+      rate: 5,
+      date: "2023.01.03",
+      liked: true,
+      likedCount: 10,
+      content:
+        "거품도 잘 나고 배송도 빠르네요! 아주 만족합니다. 거품도 잘 나고 배송도 빠르네요! 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑",
+      photo: [
+        "http://localhost:8000/images/test1.jpg",
+        "http://localhost:8000/images/test2.jpg",
+        "http://localhost:8000/images/test3.jpg",
+      ],
+    },
+    {
+      avatar: "http://localhost:8000/images/test1.jpg",
+      nickname: "그린어스",
+      rate: 1,
+      date: "2023.01.03",
+      liked: true,
+      likedCount: 10,
+      content:
+        "거품도 잘 나고 배송도 빠르네요! 아주 만족합니다. 거품도 잘 나고 배송도 빠르네요! 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑",
+      photo: [
+        "http://localhost:8000/images/test1.jpg",
+        "http://localhost:8000/images/test2.jpg",
+        "http://localhost:8000/images/test3.jpg",
+      ],
+    },
+    {
+      avatar: "http://localhost:8000/images/test1.jpg",
+      nickname: "그린어스",
+      rate: 2,
+      date: "2023.01.03",
+      liked: true,
+      likedCount: 10,
+      content:
+        "거품도 잘 나고 배송도 빠르네요! 아주 만족합니다. 거품도 잘 나고 배송도 빠르네요! 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑",
+      photo: [
+        "http://localhost:8000/images/test1.jpg",
+        "http://localhost:8000/images/test2.jpg",
+        "http://localhost:8000/images/test3.jpg",
+      ],
+    },
+    {
+      avatar: "http://localhost:8000/images/test1.jpg",
+      nickname: "그린어스",
+      rate: 5,
+      date: "2023.01.03",
+      liked: true,
+      likedCount: 10,
+      content:
+        "거품도 잘 나고 배송도 빠르네요! 아주 만족합니다. 거품도 잘 나고 배송도 빠르네요! 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑",
+      photo: [],
+    },
+    {
+      avatar: "http://localhost:8000/images/test1.jpg",
+      nickname: "그린어스",
+      rate: 3,
+      date: "2023.01.03",
+      liked: true,
+      likedCount: 10,
+      content:
+        "거품도 잘 나고 배송도 빠르네요! 아주 만족합니다. 거품도 잘 나고 배송도 빠르네요! 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑니다 제품리뷰가 3줄까지 들어갑",
+      photo: [
+        "http://localhost:8000/images/test1.jpg",
+        "http://localhost:8000/images/test2.jpg",
+        "http://localhost:8000/images/test3.jpg",
+      ],
+    },
+  ],
+};

--- a/src/components/Store/ProductDetail/Detail/Review/ReviewList/ReviewList.styles.ts
+++ b/src/components/Store/ProductDetail/Detail/Review/ReviewList/ReviewList.styles.ts
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+export const ReviewListLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;

--- a/src/components/Store/ProductDetail/Detail/Review/ReviewList/ReviewList.tsx
+++ b/src/components/Store/ProductDetail/Detail/Review/ReviewList/ReviewList.tsx
@@ -1,0 +1,19 @@
+import { ReviewDataContentType } from "../ReviewContainer";
+import ReviewItem from "./ReviewItem/ReviewItem";
+import { ReviewListLayout } from "./ReviewList.styles";
+
+interface ReviewListProps {
+  data: ReviewDataContentType[];
+}
+
+const ReviewList = ({ data }: ReviewListProps) => {
+  return (
+    <ReviewListLayout>
+      {data.map((review, index) => {
+        return <ReviewItem review={review} key={index} />;
+      })}
+    </ReviewListLayout>
+  );
+};
+
+export default ReviewList;

--- a/src/components/Store/ProductDetail/Detail/Review/ReviewSort/ReviewSort.stories.tsx
+++ b/src/components/Store/ProductDetail/Detail/Review/ReviewSort/ReviewSort.stories.tsx
@@ -1,0 +1,16 @@
+import { action } from "@storybook/addon-actions";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import ReviewSort from "./ReviewSort";
+
+export default {
+  title: "Store/ProductDetail/Detail/Review/ReviewSort",
+  component: ReviewSort,
+} as ComponentMeta<typeof ReviewSort>;
+
+const Template: ComponentStory<typeof ReviewSort> = args => <ReviewSort {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  sort: "베스트순",
+  setSort: action("정렬변경"),
+};

--- a/src/components/Store/ProductDetail/Detail/Review/ReviewSort/ReviewSort.styles.ts
+++ b/src/components/Store/ProductDetail/Detail/Review/ReviewSort/ReviewSort.styles.ts
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+
+export const ReviewSortLayout = styled.div`
+  display: flex;
+  gap: 10px;
+  border-bottom: 1px solid #eaeaea;
+`;
+
+export const ReviewSortItem = styled.div<{ selected: boolean }>`
+  font-weight: 600;
+  padding: 0 0 10px 0;
+  border-bottom: ${props => (props.selected ? "2px solid black" : "none")};
+`;

--- a/src/components/Store/ProductDetail/Detail/Review/ReviewSort/ReviewSort.tsx
+++ b/src/components/Store/ProductDetail/Detail/Review/ReviewSort/ReviewSort.tsx
@@ -1,0 +1,20 @@
+import { ReviewSortItem, ReviewSortLayout } from "./ReviewSort.styles";
+
+interface ReviewSortProps {
+  sort: string;
+  setSort: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const ReviewSort = ({ sort, setSort }: ReviewSortProps) => {
+  return (
+    <ReviewSortLayout>
+      {["베스트순", "최신순"].map(el => (
+        <ReviewSortItem key={el} selected={sort === el} onClick={() => setSort(el)}>
+          {el}
+        </ReviewSortItem>
+      ))}
+    </ReviewSortLayout>
+  );
+};
+
+export default ReviewSort;

--- a/src/components/Store/ProductDetail/Detail/Review/Status/Status.stories.tsx
+++ b/src/components/Store/ProductDetail/Detail/Review/Status/Status.stories.tsx
@@ -1,0 +1,16 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import Status from "./Status";
+
+export default {
+  title: "Store/ProductDetail/Detail/Review/Status",
+  component: Status,
+} as ComponentMeta<typeof Status>;
+
+const Template: ComponentStory<typeof Status> = args => <Status {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  avgrate: 3.6,
+  rates: [1000, 200, 30, 3, 1],
+  total: 1234,
+};

--- a/src/components/Store/ProductDetail/Detail/Review/Status/Status.styles.ts
+++ b/src/components/Store/ProductDetail/Detail/Review/Status/Status.styles.ts
@@ -1,0 +1,79 @@
+import styled from "styled-components";
+
+export const StatusLayout = styled.div`
+  max-width: 1000px;
+  height: 200px;
+  display: flex;
+  background-color: #eaeaea;
+  margin: 0 auto 50px auto;
+  border-radius: 10px;
+  padding: 30px;
+`;
+
+export const StatusStarBox = styled.div`
+  width: 500px;
+  height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-right: 1px solid black;
+  color: #aaa9a9;
+  position: relative;
+  unicode-bidi: bidi-override;
+  -webkit-text-fill-color: transparent;
+  -webkit-text-stroke-width: 1.3px;
+  -webkit-text-stroke-color: #2b2a29;
+  font-size: 50px;
+`;
+
+export const StatusStarBase = styled.div`
+  z-index: 0;
+  padding: 0;
+`;
+
+export const StatusStarFill = styled.div<{ width: number }>`
+  width: ${props => 216.25 * props.width}px;
+  position: absolute;
+  left: 142.125px;
+  color: #fff58c;
+  z-index: 1;
+  overflow: hidden;
+  -webkit-text-fill-color: black;
+`;
+
+export const StatusGraphBox = styled.div`
+  width: 450px;
+  height: 200px;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  padding-left: 50px;
+  gap: 20px;
+`;
+
+export const StatusGraphRow = styled.div`
+  display: flex;
+  gap: 10px;
+`;
+
+export const StatusGraphText = styled.div``;
+
+export const StatusGraphLineBox = styled.div`
+  position: relative;
+`;
+
+export const StatusGraphLineBase = styled.div`
+  width: 350px;
+  height: 10px;
+  background-color: white;
+`;
+
+export const StatusGraphLineFill = styled.div<{ width: string }>`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100px;
+  height: 10px;
+  background-color: black;
+  width: ${props => props.width}%;
+`;

--- a/src/components/Store/ProductDetail/Detail/Review/Status/Status.tsx
+++ b/src/components/Store/ProductDetail/Detail/Review/Status/Status.tsx
@@ -1,0 +1,43 @@
+import {
+  StatusGraphBox,
+  StatusGraphLineBase,
+  StatusGraphLineBox,
+  StatusGraphLineFill,
+  StatusGraphRow,
+  StatusGraphText,
+  StatusLayout,
+  StatusStarBase,
+  StatusStarBox,
+  StatusStarFill,
+} from "./Status.styles";
+
+interface StatusProps {
+  avgrate: number;
+  rates: number[];
+  total: number;
+}
+
+const Status = ({ avgrate, rates, total }: StatusProps) => {
+  return (
+    <StatusLayout>
+      <StatusStarBox>
+        <StatusStarBase>★★★★★</StatusStarBase>
+        <StatusStarFill width={avgrate * 0.2}>★★★★★</StatusStarFill>
+      </StatusStarBox>
+      <StatusGraphBox>
+        {rates.map((rate, index) => (
+          <StatusGraphRow key={index}>
+            <StatusGraphText>{5 - index}점</StatusGraphText>
+            <StatusGraphLineBox>
+              <StatusGraphLineBase></StatusGraphLineBase>
+              <StatusGraphLineFill width={((rate * 100) / total).toString()}></StatusGraphLineFill>
+            </StatusGraphLineBox>
+            <StatusGraphText>{rate}</StatusGraphText>
+          </StatusGraphRow>
+        ))}
+      </StatusGraphBox>
+    </StatusLayout>
+  );
+};
+
+export default Status;

--- a/src/components/Store/ProductDetail/Summary/Buy/Buy.stories.tsx
+++ b/src/components/Store/ProductDetail/Summary/Buy/Buy.stories.tsx
@@ -1,0 +1,18 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import Buy from "./Buy";
+
+export default {
+  title: "Store/ProductDetail/Summary/Buy",
+  component: Buy,
+} as ComponentMeta<typeof Buy>;
+
+const Template: ComponentStory<typeof Buy> = args => <Buy {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  badges: ["NEW", "BEST", "SALE"],
+  title: "[동구밖] 올바른린스파",
+  price: "9500",
+  summary: "3가지 식물성 오일로 모발 탄력에 도움을 주는 순식물성 린스바입니다. 상품설명 텍스트가 들어갑니다",
+  liked: "100",
+};

--- a/src/components/Store/ProductDetail/Summary/Buy/Buy.styles.ts
+++ b/src/components/Store/ProductDetail/Summary/Buy/Buy.styles.ts
@@ -1,0 +1,115 @@
+import styled from "styled-components";
+
+export const BuyLayout = styled.div`
+  width: 500px;
+`;
+
+export const BuyBadgeList = styled.ul`
+  display: flex;
+  gap: 5px;
+  margin: 0 0 15px 0;
+`;
+
+export const BuyBadgeItem = styled.li`
+  border: 1px solid black;
+  padding: 3px 10px;
+  border-radius: 5px;
+`;
+
+export const BuyProductName = styled.div`
+  font-size: 20px;
+  margin: 0 0 10px 0;
+`;
+export const BuyPrice = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  font-size: 20px;
+  margin: 0 0 20px 0;
+`;
+export const BuyInfo = styled.div`
+  min-height: 300px;
+  line-height: 1.6;
+  font-size: 18px;
+`;
+
+export const BuyShipBox = styled.div`
+  background-color: #efefef;
+  border-radius: 10px;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+export const BuyShipText = styled.div`
+  & > i {
+    font-weight: 600;
+  }
+`;
+
+export const BuyCounterBox = styled.div`
+  margin: 20px 0;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+`;
+
+export const BuyCounterTitle = styled.div`
+  font-size: 20px;
+  font-weight: 500;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const BuyCounter = styled.div`
+  display: flex;
+`;
+
+export const BuyCounterItem = styled.div`
+  width: 25px;
+  height: 25px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 1px solid black;
+`;
+
+export const BuyTotalPayBox = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  font-family: Pretendard;
+  font-size: 25px;
+  font-weight: 500;
+  line-height: 24px;
+  gap: 50px;
+  margin: 40px 0;
+`;
+
+export const BuyToalPayItem = styled.div``;
+
+export const BuyButtonBox = styled.div`
+  display: flex;
+  font-size: 15px;
+  gap: 20px;
+`;
+
+export const BuyRoundButton = styled.div`
+  border-radius: 30px;
+  height: 45px;
+  width: 200px;
+  border: 1px solid black;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const BuyCircleButton = styled.div`
+  height: 45px;
+  width: 45px;
+  border-radius: 50%;
+  border: 1px solid black;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/src/components/Store/ProductDetail/Summary/Buy/Buy.tsx
+++ b/src/components/Store/ProductDetail/Summary/Buy/Buy.tsx
@@ -1,0 +1,83 @@
+import {
+  BuyBadgeItem,
+  BuyBadgeList,
+  BuyButtonBox,
+  BuyCircleButton,
+  BuyCounter,
+  BuyCounterBox,
+  BuyCounterItem,
+  BuyCounterTitle,
+  BuyInfo,
+  BuyLayout,
+  BuyPrice,
+  BuyProductName,
+  BuyRoundButton,
+  BuyShipBox,
+  BuyShipText,
+  BuyToalPayItem,
+  BuyTotalPayBox,
+} from "./Buy.styles";
+
+interface BuyProps {
+  count: number;
+  changeCount: (op: string) => void;
+  buyProduct: () => void;
+  setLiked: () => void;
+  setBasket: () => void;
+  badges: string[];
+  title: string;
+  price: string;
+  summary: string;
+  liked: string;
+}
+
+const Buy = ({
+  count,
+  changeCount,
+  buyProduct,
+  setLiked,
+  setBasket,
+  badges,
+  title,
+  price,
+  summary,
+  liked,
+}: BuyProps) => {
+  return (
+    <BuyLayout>
+      <BuyBadgeList>
+        {badges.map(badge => (
+          <BuyBadgeItem key={badge}>{badge}</BuyBadgeItem>
+        ))}
+      </BuyBadgeList>
+      <BuyProductName>{title}</BuyProductName>
+      <BuyPrice>{price}원</BuyPrice>
+      <BuyInfo>{summary}</BuyInfo>
+      <BuyShipBox>
+        <BuyShipText>
+          혜택 <i>{Math.floor(Number(price) * 0.05)}p</i> 적립
+        </BuyShipText>
+        <BuyShipText>배송 3,000원 (50,000원 이상 무료배송) | 도서산간 배송비 추가</BuyShipText>
+      </BuyShipBox>
+      <BuyCounterBox>
+        <BuyCounterTitle>수량</BuyCounterTitle>
+        <BuyCounter>
+          <BuyCounterItem onClick={() => changeCount("minus")}>-</BuyCounterItem>
+          <BuyCounterItem>{count}</BuyCounterItem>
+          <BuyCounterItem onClick={() => changeCount("plus")}>+</BuyCounterItem>
+        </BuyCounter>
+      </BuyCounterBox>
+      <BuyTotalPayBox>
+        <BuyToalPayItem>주문금액 ({count}개)</BuyToalPayItem>
+        <BuyToalPayItem>{price}원</BuyToalPayItem>
+      </BuyTotalPayBox>
+      <BuyButtonBox>
+        <BuyCircleButton onClick={setLiked}>♡{liked}</BuyCircleButton>
+        <BuyRoundButton onClick={setBasket}>장바구니</BuyRoundButton>
+        <BuyRoundButton onClick={buyProduct}>바로구매</BuyRoundButton>
+      </BuyButtonBox>
+    </BuyLayout>
+  );
+};
+
+export default Buy;

--- a/src/components/Store/ProductDetail/Summary/Buy/BuyContainer.tsx
+++ b/src/components/Store/ProductDetail/Summary/Buy/BuyContainer.tsx
@@ -1,0 +1,35 @@
+import axios from "axios";
+import useSetQueryMutate from "../../../../../hooks/useSetQueryMutate";
+import { SummaryType } from "../SummaryContainer";
+import Buy from "./Buy";
+import useBuy from "./BuyHook";
+
+interface BuyContainerProps {
+  data: SummaryType;
+}
+
+const BuyContainer = ({ data }: BuyContainerProps) => {
+  const { id, count, changeCount, buyProduct } = useBuy();
+  const { mutate: basketMutate } = useSetQueryMutate(
+    id => axios.post("http://localhost:8000/basket", { id }),
+    ["Store", "ProductDetail", "summary", "Buy", "basket", id],
+  );
+
+  const { mutate: likedMutate } = useSetQueryMutate(
+    id => axios.post("http://localhost:8000/liked", { id }),
+    ["Store", "ProductDetail", "summary", "Buy", "liked", id],
+  );
+
+  return (
+    <Buy
+      {...data}
+      count={count}
+      changeCount={changeCount}
+      buyProduct={buyProduct}
+      setBasket={() => basketMutate(id)}
+      setLiked={() => likedMutate(id)}
+    ></Buy>
+  );
+};
+
+export default BuyContainer;

--- a/src/components/Store/ProductDetail/Summary/Buy/BuyHook.tsx
+++ b/src/components/Store/ProductDetail/Summary/Buy/BuyHook.tsx
@@ -1,0 +1,22 @@
+import { useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
+const useBuy = () => {
+  const [count, setCount] = useState(0);
+  const navigation = useNavigate();
+  const { id } = useParams();
+
+  const buyProduct = () => {
+    navigation("/store/buy", { state: { id, count } });
+  };
+
+  const changeCount = (op: string) => {
+    if (op === "plus") return setCount(count + 1);
+    if (count === 0) return;
+    return setCount(count - 1);
+  };
+
+  return { id, count, changeCount, buyProduct };
+};
+
+export default useBuy;

--- a/src/components/Store/ProductDetail/Summary/Summary.stories.tsx
+++ b/src/components/Store/ProductDetail/Summary/Summary.stories.tsx
@@ -1,0 +1,26 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import Summary from "./Summary";
+
+export default {
+  title: "Store/ProductDetail/Summary/Summary",
+  component: Summary,
+} as ComponentMeta<typeof Summary>;
+
+const Template: ComponentStory<typeof Summary> = args => <Summary {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  data: {
+    thumnail: [
+      "http://localhost:8000/images/test1.jpg",
+      "http://localhost:8000/images/test2.jpg",
+      "http://localhost:8000/images/test3.jpg",
+    ],
+    category: "욕실",
+    badges: ["NEW", "BEST", "SALE"],
+    title: "[동구밖] 올바른린스파",
+    price: "9500",
+    summary: "3가지 식물성 오일로 모발 탄력에 도움을 주는 순식물성 린스바입니다. 상품설명 텍스트가 들어갑니다",
+    liked: "100",
+  },
+};

--- a/src/components/Store/ProductDetail/Summary/Summary.styles.ts
+++ b/src/components/Store/ProductDetail/Summary/Summary.styles.ts
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+
+export const SummaryLayout = styled.div`
+  width: 100%;
+  margin: 50px 0 0 0;
+`;
+
+export const SummaryRow = styled.div`
+  display: flex;
+  max-width: 1200px;
+  justify-content: space-between;
+  margin: auto;
+`;

--- a/src/components/Store/ProductDetail/Summary/Summary.tsx
+++ b/src/components/Store/ProductDetail/Summary/Summary.tsx
@@ -1,0 +1,21 @@
+import BuyContainer from "./Buy/BuyContainer";
+import { SummaryLayout, SummaryRow } from "./Summary.styles";
+import { SummaryType } from "./SummaryContainer";
+import Thumnail from "./Thumnail/Thumnail";
+
+interface SummaryProps {
+  data: SummaryType;
+}
+
+const Summary = ({ data }: SummaryProps) => {
+  return (
+    <SummaryLayout>
+      <SummaryRow>
+        <Thumnail photos={data.thumnail} />
+        <BuyContainer data={data} />
+      </SummaryRow>
+    </SummaryLayout>
+  );
+};
+
+export default Summary;

--- a/src/components/Store/ProductDetail/Summary/SummaryContainer.tsx
+++ b/src/components/Store/ProductDetail/Summary/SummaryContainer.tsx
@@ -1,0 +1,30 @@
+import useSuspenseQuery from "../../../../hooks/useSuspenseQuery";
+import Summary from "./Summary";
+
+export interface SummaryType {
+  thumnail: string[];
+  category: string;
+  badges: string[];
+  title: string;
+  price: string;
+  summary: string;
+  liked: string;
+}
+
+interface SummaryContainerProps {
+  setCondition: React.Dispatch<
+    React.SetStateAction<{
+      category?: string | undefined;
+    }>
+  >;
+}
+
+const SummaryContainer = ({ setCondition }: SummaryContainerProps) => {
+  const { data } = useSuspenseQuery<SummaryType>(["Store", "ProductDetail", "summary", "1"], "summary", e =>
+    setCondition({ category: e.category }),
+  );
+
+  return <Summary data={data} />;
+};
+
+export default SummaryContainer;

--- a/src/components/Store/ProductDetail/Summary/Thumnail/Thumnail.stories.tsx
+++ b/src/components/Store/ProductDetail/Summary/Thumnail/Thumnail.stories.tsx
@@ -1,0 +1,18 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import Thumnail from "./Thumnail";
+
+export default {
+  title: "Store/ProductDetail/Summary/Thumnail",
+  component: Thumnail,
+} as ComponentMeta<typeof Thumnail>;
+
+const Template: ComponentStory<typeof Thumnail> = args => <Thumnail {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  photos: [
+    "http://localhost:8000/images/test1.jpg",
+    "http://localhost:8000/images/test2.jpg",
+    "http://localhost:8000/images/test3.jpg",
+  ],
+};

--- a/src/components/Store/ProductDetail/Summary/Thumnail/Thumnail.styles.ts
+++ b/src/components/Store/ProductDetail/Summary/Thumnail/Thumnail.styles.ts
@@ -1,0 +1,25 @@
+import styled from "styled-components";
+
+export const ThumnailLayout = styled.div`
+  width: 500px;
+`;
+
+export const ThumnailBigImgBox = styled.div`
+  margin: 0 0 10px 0;
+`;
+
+export const ThumnailBigImg = styled.img`
+  width: 500px;
+  height: 500px;
+  background-color: #eaeaea;
+`;
+export const ThumnailSmallImgBox = styled.div`
+  display: flex;
+  gap: 5px;
+`;
+
+export const ThumnailSmallImg = styled.img`
+  width: 100px;
+  height: 100px;
+  background-color: #eaeaea;
+`;

--- a/src/components/Store/ProductDetail/Summary/Thumnail/Thumnail.tsx
+++ b/src/components/Store/ProductDetail/Summary/Thumnail/Thumnail.tsx
@@ -1,0 +1,30 @@
+import { useState } from "react";
+import {
+  ThumnailBigImg,
+  ThumnailBigImgBox,
+  ThumnailLayout,
+  ThumnailSmallImg,
+  ThumnailSmallImgBox,
+} from "./Thumnail.styles";
+
+interface ThumnailProps {
+  photos: string[];
+}
+
+const Thumnail = ({ photos }: ThumnailProps) => {
+  const [selectedThumnail, setSelectedThumnail] = useState(0);
+  return (
+    <ThumnailLayout>
+      <ThumnailBigImgBox>
+        <ThumnailBigImg src={photos[selectedThumnail]} />
+      </ThumnailBigImgBox>
+      <ThumnailSmallImgBox>
+        {photos.map((photo, index) => (
+          <ThumnailSmallImg src={photo} key={photo} onClick={() => setSelectedThumnail(index)} />
+        ))}
+      </ThumnailSmallImgBox>
+    </ThumnailLayout>
+  );
+};
+
+export default Thumnail;

--- a/src/components/Store/ProductList/ProductCardList/ProductCardList.stories.tsx
+++ b/src/components/Store/ProductList/ProductCardList/ProductCardList.stories.tsx
@@ -1,0 +1,116 @@
+import { action } from "@storybook/addon-actions";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import ProductCardList from "./ProductCardList";
+
+export default {
+  title: "Store/ProductList/ProductCardList",
+  component: ProductCardList,
+} as ComponentMeta<typeof ProductCardList>;
+
+const Template: ComponentStory<typeof ProductCardList> = args => <ProductCardList {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  data: {
+    totalCount: 100,
+    contents: [
+      {
+        id: 1,
+        category: "1",
+        brand: "그리너스",
+        title: "마일드 고체치약 30정입",
+        discountRate: "45",
+        price: "5900",
+        badges: ["best", "sale"],
+        liked: true,
+      },
+      {
+        id: 2,
+        category: "1",
+        brand: "그리너스",
+        title: "마일드 고체치약 30정입",
+        discountRate: "45",
+        price: "5900",
+        badges: ["best", "sale"],
+        liked: false,
+      },
+      {
+        id: 3,
+        category: "2",
+        brand: "그리너스",
+        title: "마일드 고체치약 30정입",
+        discountRate: "45",
+        price: "5900",
+        badges: ["best", "sale"],
+        liked: false,
+      },
+      {
+        id: 4,
+        category: "1",
+        brand: "그리너스",
+        title: "마일드 고체치약 30정입",
+        discountRate: "45",
+        price: "5900",
+        badges: ["best", "sale"],
+        liked: true,
+      },
+      {
+        id: 5,
+        category: "1",
+        brand: "그리너스",
+        title: "마일드 고체치약 30정입",
+        discountRate: "45",
+        price: "5900",
+        badges: ["best", "sale"],
+        liked: true,
+      },
+      {
+        id: 6,
+        category: "2",
+        brand: "그리너스",
+        title: "마일드 고체치약 30정입",
+        discountRate: "45",
+        price: "5900",
+        badges: ["best", "sale"],
+        liked: false,
+      },
+      {
+        id: 7,
+        category: "1",
+        brand: "그리너스",
+        title: "마일드 고체치약 30정입",
+        discountRate: "45",
+        price: "5900",
+        badges: ["best", "sale"],
+        liked: true,
+      },
+      {
+        id: 8,
+        category: "1",
+        brand: "그리너스",
+        title: "마일드 고체치약 30정입",
+        discountRate: "45",
+        price: "5900",
+        badges: ["best", "sale"],
+        liked: true,
+      },
+      {
+        id: 9,
+        category: "2",
+        brand: "그리너스",
+        title: "마일드 고체치약 30정입",
+        discountRate: "45",
+        price: "5900",
+        badges: ["best", "sale"],
+        liked: false,
+      },
+    ],
+  },
+  condition: {
+    category: "전체",
+    filter: [],
+    sort: "인기순",
+    page: 1,
+  },
+  setCondition: action("정렬변경"),
+};

--- a/src/components/Store/ProductList/ProductCardList/ProductCardList.styles.ts
+++ b/src/components/Store/ProductList/ProductCardList/ProductCardList.styles.ts
@@ -1,0 +1,26 @@
+import styled from "styled-components";
+
+export const ProductCardListLayout = styled.div`
+  width: 100%;
+  margin: 0 0 50px 0;
+`;
+
+export const ProductCardListGrid = styled.div`
+  max-width: 1200px;
+  margin: auto;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-column-gap: 15px;
+  grid-row-gap: 50px;
+`;
+
+export const ProductCardListTopBox = styled.div`
+  max-width: 1200px;
+  display: flex;
+  justify-content: space-between;
+  margin: 0 auto 20px auto;
+`;
+
+export const ProductCardListTotalText = styled.span`
+  font-weight: 600;
+`;

--- a/src/components/Store/ProductList/ProductCardList/ProductCardList.tsx
+++ b/src/components/Store/ProductList/ProductCardList/ProductCardList.tsx
@@ -1,0 +1,37 @@
+import StoreSort from "./ProductSort/ProductSort";
+import {
+  ProductCardListGrid,
+  ProductCardListLayout,
+  ProductCardListTopBox,
+  ProductCardListTotalText,
+} from "./ProductCardList.styles";
+import ProductCard from "../../Common/ProductCard/ProductCard";
+import { conditionType, setConditionType } from "../../../../pages/Store/ProductList";
+import { ProductCardListDataType } from "./ProductCardListContainer";
+import { UseMutateFunction } from "react-query";
+import { AxiosResponse } from "axios";
+
+interface ProductCardListProps {
+  data: ProductCardListDataType;
+  condition: conditionType;
+  setCondition: setConditionType;
+  changeLiked: UseMutateFunction<AxiosResponse<unknown, unknown>, unknown, unknown, unknown>;
+}
+
+const ProductCardList = ({ data, condition, setCondition, changeLiked }: ProductCardListProps) => {
+  return (
+    <ProductCardListLayout>
+      <ProductCardListTopBox>
+        <ProductCardListTotalText>전체 {data.totalCount}개</ProductCardListTotalText>
+        <StoreSort condition={condition} setCondition={setCondition} />
+      </ProductCardListTopBox>
+      <ProductCardListGrid>
+        {data.contents.map(content => (
+          <ProductCard {...content} key={content.id} changeLiked={changeLiked} />
+        ))}
+      </ProductCardListGrid>
+    </ProductCardListLayout>
+  );
+};
+
+export default ProductCardList;

--- a/src/components/Store/ProductList/ProductCardList/ProductCardListContainer.tsx
+++ b/src/components/Store/ProductList/ProductCardList/ProductCardListContainer.tsx
@@ -1,0 +1,61 @@
+import axios from "axios";
+import useSetQueryMutate from "../../../../hooks/useSetQueryMutate";
+import useSuspenseQuery from "../../../../hooks/useSuspenseQuery";
+import { conditionType, setConditionType } from "../../../../pages/Store/ProductList";
+import { ProductCardProps } from "../../Common/ProductCard/ProductCard";
+import ProductCardList from "./ProductCardList";
+
+export interface ProductCardListDataType {
+  totalCount: number;
+  contents: {
+    id: number;
+    category: string;
+    brand: string;
+    title: string;
+    discountRate: string;
+    price: string;
+    badges: string[];
+    liked: boolean;
+  }[];
+}
+
+interface ProductCardListContainerProps {
+  condition: conditionType;
+  setCondition: setConditionType;
+}
+
+const ProductCardListContainer = ({ condition, setCondition }: ProductCardListContainerProps) => {
+  const { category, filter, sort, page } = condition;
+  const { data } = useSuspenseQuery<ProductCardListDataType>(
+    ["Store", "ProductList", "ProductCardList", category, filter, sort, page],
+    `product?category=${category}&filter=${filter}&sort=${sort}&page=${page}`,
+  );
+
+  const { mutate } = useSetQueryMutate<
+    { id: number },
+    (data: { totalCount: number; contents: ProductCardProps[] }) => {
+      totalCount: number;
+      contents: ProductCardProps[];
+    }
+  >(
+    id => axios.post("http://localhost:8000/product", { id }),
+    ["Store", "ProductList", "ProductCardList", category, filter, sort, page],
+    e => {
+      return (data: { totalCount: number; contents: ProductCardProps[] }) => {
+        return {
+          totalCount: data.totalCount,
+          contents: data.contents.map(el => {
+            if (el.id === e.data.id) {
+              console.log(el.id);
+              return { ...el, liked: !el.liked };
+            }
+            return el;
+          }),
+        };
+      };
+    },
+  );
+  return <ProductCardList data={data} condition={condition} setCondition={setCondition} changeLiked={mutate} />;
+};
+
+export default ProductCardListContainer;

--- a/src/components/Store/ProductList/ProductCardList/ProductSort/ProductSort.stories.tsx
+++ b/src/components/Store/ProductList/ProductCardList/ProductSort/ProductSort.stories.tsx
@@ -1,0 +1,16 @@
+import { action } from "@storybook/addon-actions";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import ProductSort from "./ProductSort";
+
+export default {
+  title: "Store/ProductList/ProductCardList/ProductSort",
+  component: ProductSort,
+} as ComponentMeta<typeof ProductSort>;
+
+const Template: ComponentStory<typeof ProductSort> = args => <ProductSort {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  condition: { category: "전체", filter: [], sort: "인기순", page: 1 },
+  setCondition: action("정렬방식 변경"),
+};

--- a/src/components/Store/ProductList/ProductCardList/ProductSort/ProductSort.styles.ts
+++ b/src/components/Store/ProductList/ProductCardList/ProductSort/ProductSort.styles.ts
@@ -1,0 +1,14 @@
+import styled from "styled-components";
+
+export const ProductSortLayout = styled.div`
+  max-width: 1200px;
+`;
+
+export const ProductSortRow = styled.div`
+  display: flex;
+  gap: 10px;
+`;
+
+export const ProductSortText = styled.span<{ same: boolean }>`
+  font-weight: ${props => (props.same ? "600" : "400")};
+`;

--- a/src/components/Store/ProductList/ProductCardList/ProductSort/ProductSort.tsx
+++ b/src/components/Store/ProductList/ProductCardList/ProductSort/ProductSort.tsx
@@ -1,0 +1,23 @@
+import { conditionType, setConditionType } from "../../../../../pages/Store/ProductList";
+import { ProductSortLayout, ProductSortRow, ProductSortText } from "./ProductSort.styles";
+
+interface ProductSortProps {
+  condition: conditionType;
+  setCondition: setConditionType;
+}
+
+const ProductSort = ({ condition, setCondition }: ProductSortProps) => {
+  return (
+    <ProductSortLayout>
+      <ProductSortRow>
+        {["인기순", "신상품순", "낮은가격순", "높은가격순"].map(e => (
+          <ProductSortText key={e} same={e === condition.sort} onClick={() => setCondition({ ...condition, sort: e })}>
+            {e}
+          </ProductSortText>
+        ))}
+      </ProductSortRow>
+    </ProductSortLayout>
+  );
+};
+
+export default ProductSort;

--- a/src/components/Store/ProductList/ProductCarousel/ProductCarousel.stories.tsx
+++ b/src/components/Store/ProductList/ProductCarousel/ProductCarousel.stories.tsx
@@ -1,0 +1,22 @@
+import { action } from "@storybook/addon-actions";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import ProductCarousel from "./ProductCarousel";
+
+export default {
+  title: "Store/ProductList/ProductCarousel",
+  component: ProductCarousel,
+} as ComponentMeta<typeof ProductCarousel>;
+
+const Template: ComponentStory<typeof ProductCarousel> = args => <ProductCarousel {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  data: [
+    "http://localhost:8000/images/test1.jpg",
+    "http://localhost:8000/images/test2.jpg",
+    "http://localhost:8000/images/test3.jpg",
+  ],
+  order: 1,
+  movePrevOrder: action("이전사진으로이동"),
+  moveNextOrder: action("다음사진으로이동"),
+};

--- a/src/components/Store/ProductList/ProductCarousel/ProductCarousel.styles.ts
+++ b/src/components/Store/ProductList/ProductCarousel/ProductCarousel.styles.ts
@@ -1,0 +1,36 @@
+import styled from "styled-components";
+
+export const ProductCarouselLayout = styled.div`
+  width: 100%;
+  height: 300px;
+  margin: 50px 0 80px 0;
+`;
+
+export const ProductCarouselButton = styled.button<{ direction: string }>`
+  position: absolute;
+  top: 50%;
+  transform: translate(0, -50%);
+  ${props => (props.direction === "left" ? "left: 10px;" : "right: 10px;")};
+  font-size: 50px;
+  font-weight: 600;
+  background: none;
+`;
+
+export const ProductCarouselImgBox = styled.div`
+  position: relative;
+  max-width: 1200px;
+  height: 300px;
+  margin: auto;
+`;
+
+export const ProductCarouselImg = styled.img`
+  width: 100%;
+  height: 100%;
+  margin: auto;
+  background: #d9d9d9;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 40px;
+  font-weight: 500;
+`;

--- a/src/components/Store/ProductList/ProductCarousel/ProductCarousel.tsx
+++ b/src/components/Store/ProductList/ProductCarousel/ProductCarousel.tsx
@@ -1,0 +1,31 @@
+import {
+  ProductCarouselButton,
+  ProductCarouselImg,
+  ProductCarouselImgBox,
+  ProductCarouselLayout,
+} from "./ProductCarousel.styles";
+
+interface ProductCarouselProps {
+  data: string[];
+  order: number;
+  movePrevOrder: () => void;
+  moveNextOrder: () => void;
+}
+
+const ProductCarousel = ({ data, order, movePrevOrder, moveNextOrder }: ProductCarouselProps) => {
+  return (
+    <ProductCarouselLayout>
+      <ProductCarouselImgBox>
+        <ProductCarouselButton direction={"left"} onClick={movePrevOrder}>
+          &lt;
+        </ProductCarouselButton>
+        <ProductCarouselImg src={data[order]} />
+        <ProductCarouselButton direction={"right"} onClick={moveNextOrder}>
+          &gt;
+        </ProductCarouselButton>
+      </ProductCarouselImgBox>
+    </ProductCarouselLayout>
+  );
+};
+
+export default ProductCarousel;

--- a/src/components/Store/ProductList/ProductCarousel/ProductCarouselContainer.tsx
+++ b/src/components/Store/ProductList/ProductCarousel/ProductCarouselContainer.tsx
@@ -1,0 +1,12 @@
+import useSuspenseQuery from "../../../../hooks/useSuspenseQuery";
+import ProductCarousel from "./ProductCarousel";
+import useProductCarousel from "./ProductCarouselHook";
+
+const ProductCarouselContainer = () => {
+  const { data } = useSuspenseQuery<string[]>(["Store", "productList", "productCarousel"], "productcarousel");
+  const { order, movePrevOrder, moveNextOrder } = useProductCarousel(data.length);
+
+  return <ProductCarousel data={data} order={order} movePrevOrder={movePrevOrder} moveNextOrder={moveNextOrder} />;
+};
+
+export default ProductCarouselContainer;

--- a/src/components/Store/ProductList/ProductCarousel/ProductCarouselHook.tsx
+++ b/src/components/Store/ProductList/ProductCarousel/ProductCarouselHook.tsx
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+const useProductCarousel = (length: number) => {
+  const [order, setOrder] = useState(0);
+  useEffect(() => {
+    setInterval(() => {
+      setOrder(order => (order === length - 1 ? 0 : order + 1));
+    }, 2000);
+  }, []);
+
+  const movePrevOrder = () => {
+    setOrder(order === 0 ? length - 1 : order - 1);
+  };
+
+  const moveNextOrder = () => {
+    setOrder(order === length - 1 ? 0 : order + 1);
+  };
+
+  return { order, movePrevOrder, moveNextOrder };
+};
+
+export default useProductCarousel;

--- a/src/components/Store/ProductList/ProductFilterBlock/ProductFilterBlock.stories.tsx
+++ b/src/components/Store/ProductList/ProductFilterBlock/ProductFilterBlock.stories.tsx
@@ -1,0 +1,22 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import ProductFilterBlock from "./ProductFilterBlock";
+import { action } from "@storybook/addon-actions";
+
+export default {
+  title: "Store/ProductList/ProductFilterBlock",
+  component: ProductFilterBlock,
+} as ComponentMeta<typeof ProductFilterBlock>;
+
+const Template: ComponentStory<typeof ProductFilterBlock> = args => <ProductFilterBlock {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  condition: {
+    category: "전체",
+    filter: [],
+    sort: "인기순",
+    page: 1,
+  },
+  setCheckboxFilter: action("체크박스 선택"),
+  setRadioFilter: action("라디오 선택"),
+};

--- a/src/components/Store/ProductList/ProductFilterBlock/ProductFilterBlock.styles.ts
+++ b/src/components/Store/ProductList/ProductFilterBlock/ProductFilterBlock.styles.ts
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+
+export const ProductFilterBlockLayout = styled.div`
+  width: 100%;
+  margin: 50px 0 100px 0;
+`;
+
+export const ProductFilterBlockCol = styled.div`
+  display: flex;
+  flex-direction: column;
+  max-width: 1200px;
+  margin: auto;
+`;

--- a/src/components/Store/ProductList/ProductFilterBlock/ProductFilterBlock.tsx
+++ b/src/components/Store/ProductList/ProductFilterBlock/ProductFilterBlock.tsx
@@ -1,0 +1,57 @@
+import { conditionType, filterType } from "../../../../pages/Store/ProductList";
+import { ProductFilterBlockCol, ProductFilterBlockLayout } from "./ProductFilterBlock.styles";
+import StoreFilterRow from "./ProductFilterRow/ProductFilterRow";
+import SelectedProductFilterList from "./SelectedProductFilterList/SelectedProductFilterList";
+
+interface ProductFilterBlockProps {
+  condition: conditionType;
+  setCheckboxFilter: (clickedFilter: filterType) => void;
+  setRadioFilter: (clickedFilter: filterType) => void;
+}
+
+const ProductFilterBlock = ({ condition, setCheckboxFilter, setRadioFilter }: ProductFilterBlockProps) => {
+  return (
+    <ProductFilterBlockLayout>
+      <ProductFilterBlockCol>
+        <StoreFilterRow
+          title={"브랜드"}
+          list={[
+            { text: "잇츠베러", value: "0" },
+            { text: "젤러스 스윗", value: "1" },
+            { text: "비건 포레스트", value: "2" },
+            { text: "저스트에그", value: "3" },
+            { text: "비건타민", value: "4" },
+            { text: "바오푸드", value: "5" },
+            { text: "로마린다", value: "6" },
+          ]}
+          setCheckboxFilter={setCheckboxFilter}
+          setRadioFilter={setRadioFilter}
+        />
+        <StoreFilterRow
+          title={"가격"}
+          list={[
+            { text: "10000원이하", value: "7", name: "price" },
+            { text: "10000~30000", value: "8", name: "price" },
+            { text: "30000~50000", value: "9", name: "price" },
+            { text: "50000이상", value: "10", name: "price" },
+          ]}
+          setCheckboxFilter={setCheckboxFilter}
+          setRadioFilter={setRadioFilter}
+        />
+        <StoreFilterRow
+          title={"제품상태"}
+          list={[
+            { text: "무료배송", value: "11" },
+            { text: "할인 상품", value: "12" },
+            { text: "품절상품 제외", value: "13" },
+          ]}
+          setCheckboxFilter={setCheckboxFilter}
+          setRadioFilter={setRadioFilter}
+        />
+        <SelectedProductFilterList selectedFilters={condition.filter} />
+      </ProductFilterBlockCol>
+    </ProductFilterBlockLayout>
+  );
+};
+
+export default ProductFilterBlock;

--- a/src/components/Store/ProductList/ProductFilterBlock/ProductFilterBlockContainer.tsx
+++ b/src/components/Store/ProductList/ProductFilterBlock/ProductFilterBlockContainer.tsx
@@ -1,0 +1,37 @@
+import { conditionType, filterType, setConditionType } from "../../../../pages/Store/ProductList";
+import ProductFilterBlock from "./ProductFilterBlock";
+
+interface ProductFilterBlockProps {
+  condition: conditionType;
+  setCondition: setConditionType;
+}
+
+const ProductFilterBlockContainer = ({ condition, setCondition }: ProductFilterBlockProps) => {
+  const setCheckboxFilter = (clickedFilter: filterType) => {
+    const filtered = condition.filter.filter(el => {
+      if (el.value === clickedFilter.value) return false;
+      return true;
+    });
+
+    if (filtered.length === condition.filter.length) {
+      setCondition({ ...condition, filter: [...condition.filter, clickedFilter] });
+    } else {
+      setCondition({ ...condition, filter: filtered });
+    }
+  };
+
+  const setRadioFilter = (clickedFilter: filterType) => {
+    const filtered = condition.filter.filter(el => {
+      if (el.name === clickedFilter.name) return false;
+      return true;
+    });
+
+    setCondition({ ...condition, filter: [...filtered, clickedFilter] });
+  };
+
+  return (
+    <ProductFilterBlock condition={condition} setCheckboxFilter={setCheckboxFilter} setRadioFilter={setRadioFilter} />
+  );
+};
+
+export default ProductFilterBlockContainer;

--- a/src/components/Store/ProductList/ProductFilterBlock/ProductFilterRow/CheckBoxFilter/CheckBoxFilter.stories.tsx
+++ b/src/components/Store/ProductList/ProductFilterBlock/ProductFilterRow/CheckBoxFilter/CheckBoxFilter.stories.tsx
@@ -1,0 +1,15 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import CheckBoxFilter from "./CheckBoxFilter";
+
+export default {
+  title: "Store/ProductList/ProductFilterBlock/ProductFilterRow/CheckBoxFilter",
+  component: CheckBoxFilter,
+} as ComponentMeta<typeof CheckBoxFilter>;
+
+const Template: ComponentStory<typeof CheckBoxFilter> = args => <CheckBoxFilter {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  value: "잇츠베러",
+  text: "잇츠베러",
+};

--- a/src/components/Store/ProductList/ProductFilterBlock/ProductFilterRow/CheckBoxFilter/CheckBoxFilter.styles.ts
+++ b/src/components/Store/ProductList/ProductFilterBlock/ProductFilterRow/CheckBoxFilter/CheckBoxFilter.styles.ts
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+export const CheckBoxFilterLayout = styled.li`
+  display: flex;
+  gap: 5px;
+  align-items: center;
+`;
+
+export const CheckBoxFilterInput = styled.input``;
+
+export const CheckBoxFilterLabel = styled.label``;

--- a/src/components/Store/ProductList/ProductFilterBlock/ProductFilterRow/CheckBoxFilter/CheckBoxFilter.tsx
+++ b/src/components/Store/ProductList/ProductFilterBlock/ProductFilterRow/CheckBoxFilter/CheckBoxFilter.tsx
@@ -1,0 +1,24 @@
+import { filterType } from "../../../../../../pages/Store/ProductList";
+import { CheckBoxFilterInput, CheckBoxFilterLabel, CheckBoxFilterLayout } from "./CheckBoxFilter.styles";
+
+interface CheckBoxFilterProps {
+  value: string;
+  text: string;
+  setCheckboxFilter: (clickedFilter: filterType) => void;
+}
+
+const CheckBoxFilter = ({ text, value, setCheckboxFilter }: CheckBoxFilterProps) => {
+  return (
+    <CheckBoxFilterLayout>
+      <CheckBoxFilterInput
+        type="checkbox"
+        id={text}
+        value={value}
+        onClick={() => setCheckboxFilter({ name: null, value, text })}
+      />
+      <CheckBoxFilterLabel htmlFor={text}>{text}</CheckBoxFilterLabel>
+    </CheckBoxFilterLayout>
+  );
+};
+
+export default CheckBoxFilter;

--- a/src/components/Store/ProductList/ProductFilterBlock/ProductFilterRow/ProductFilterRow.stories.tsx
+++ b/src/components/Store/ProductList/ProductFilterBlock/ProductFilterRow/ProductFilterRow.stories.tsx
@@ -1,0 +1,34 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import ProductFilterRow from "./ProductFilterRow";
+
+export default {
+  title: "Store/ProductList/ProductFilterBlock/ProductFilterRow",
+  component: ProductFilterRow,
+} as ComponentMeta<typeof ProductFilterRow>;
+
+const Template: ComponentStory<typeof ProductFilterRow> = args => <ProductFilterRow {...args} />;
+
+export const CheckBox = Template.bind({});
+CheckBox.args = {
+  title: "브랜드",
+  list: [
+    { text: "잇츠베러", value: "0" },
+    { text: "젤러스 스윗", value: "1" },
+    { text: "비건 포레스트", value: "2" },
+    { text: "저스트에그", value: "3" },
+    { text: "비건타민", value: "4" },
+    { text: "바오푸드", value: "5" },
+    { text: "로마린다", value: "6" },
+  ],
+};
+
+export const Radio = Template.bind({});
+Radio.args = {
+  title: "가격",
+  list: [
+    { text: "10000원이하", value: "7", name: "price" },
+    { text: "10000~30000", value: "8", name: "price" },
+    { text: "30000~50000", value: "9", name: "price" },
+    { text: "50000이상", value: "10", name: "price" },
+  ],
+};

--- a/src/components/Store/ProductList/ProductFilterBlock/ProductFilterRow/ProductFilterRow.styles.ts
+++ b/src/components/Store/ProductList/ProductFilterBlock/ProductFilterRow/ProductFilterRow.styles.ts
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+
+export const ProductFilterRowLayout = styled.div`
+  display: flex;
+  padding: 10px 0;
+  & + & {
+    border-top: 1px solid #eaeaea;
+  }
+`;
+
+export const ProductFilterRowTitle = styled.div`
+  width: 100px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+`;
+
+export const ProductFilterRowList = styled.ul`
+  display: flex;
+  gap: 10px;
+`;

--- a/src/components/Store/ProductList/ProductFilterBlock/ProductFilterRow/ProductFilterRow.tsx
+++ b/src/components/Store/ProductList/ProductFilterBlock/ProductFilterRow/ProductFilterRow.tsx
@@ -1,0 +1,30 @@
+import StoreFilterCheckBox from "./CheckBoxFilter/CheckBoxFilter";
+import StoreFilterRadio from "./RadioFilter/RadioFilter";
+import { ProductFilterRowLayout, ProductFilterRowList, ProductFilterRowTitle } from "./ProductFilterRow.styles";
+import { filterType } from "../../../../../pages/Store/ProductList";
+
+interface ProductFilterRowProps {
+  title: string;
+  list: { text: string; value: string; name?: string }[];
+  setCheckboxFilter: (clickedFilter: filterType) => void;
+  setRadioFilter: (clickedFilter: filterType) => void;
+}
+
+const ProductFilterRow = ({ title, list, setCheckboxFilter, setRadioFilter }: ProductFilterRowProps) => {
+  return (
+    <ProductFilterRowLayout>
+      <ProductFilterRowTitle>{title}</ProductFilterRowTitle>
+      <ProductFilterRowList>
+        {list.map(({ text, value, name }) =>
+          name ? (
+            <StoreFilterRadio text={text} value={value} name={name} key={text} setRadioFilter={setRadioFilter} />
+          ) : (
+            <StoreFilterCheckBox text={text} value={value} key={text} setCheckboxFilter={setCheckboxFilter} />
+          ),
+        )}
+      </ProductFilterRowList>
+    </ProductFilterRowLayout>
+  );
+};
+
+export default ProductFilterRow;

--- a/src/components/Store/ProductList/ProductFilterBlock/ProductFilterRow/RadioFilter/RadioFilter.stories.tsx
+++ b/src/components/Store/ProductList/ProductFilterBlock/ProductFilterRow/RadioFilter/RadioFilter.stories.tsx
@@ -1,0 +1,16 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import RadioFilter from "./RadioFilter";
+
+export default {
+  title: "Store/ProductList/ProductFilterBlock/ProductFilterRow/RadioFilter",
+  component: RadioFilter,
+} as ComponentMeta<typeof RadioFilter>;
+
+const Template: ComponentStory<typeof RadioFilter> = args => <RadioFilter {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  text: "10000원미만",
+  value: "100000",
+  name: "price",
+};

--- a/src/components/Store/ProductList/ProductFilterBlock/ProductFilterRow/RadioFilter/RadioFilter.styles.ts
+++ b/src/components/Store/ProductList/ProductFilterBlock/ProductFilterRow/RadioFilter/RadioFilter.styles.ts
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+export const RadioFilterLayout = styled.li``;
+
+export const RadioFilterInput = styled.input``;
+
+export const RadioFilterLabel = styled.label``;

--- a/src/components/Store/ProductList/ProductFilterBlock/ProductFilterRow/RadioFilter/RadioFilter.tsx
+++ b/src/components/Store/ProductList/ProductFilterBlock/ProductFilterRow/RadioFilter/RadioFilter.tsx
@@ -1,0 +1,26 @@
+import { filterType, setConditionType } from "../../../../../../pages/Store/ProductList";
+import { RadioFilterInput, RadioFilterLabel, RadioFilterLayout } from "./RadioFilter.styles";
+
+interface RadioFilterProps {
+  text: string;
+  name: string;
+  value: string;
+  setRadioFilter: (clickedFilter: filterType) => void;
+}
+
+const RadioFilter = ({ text, name, value, setRadioFilter }: RadioFilterProps) => {
+  return (
+    <RadioFilterLayout>
+      <RadioFilterInput
+        type="radio"
+        id={text}
+        name={name}
+        value={value}
+        onClick={() => setRadioFilter({ name, value, text })}
+      />
+      <RadioFilterLabel htmlFor={text}>{text}</RadioFilterLabel>
+    </RadioFilterLayout>
+  );
+};
+
+export default RadioFilter;

--- a/src/components/Store/ProductList/ProductFilterBlock/SelectedProductFilterList/SelectedProductFilter/SelectedProductFilter.stories.tsx
+++ b/src/components/Store/ProductList/ProductFilterBlock/SelectedProductFilterList/SelectedProductFilter/SelectedProductFilter.stories.tsx
@@ -1,0 +1,14 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import SelectedProductFilter from "./SelectedProductFilter";
+
+export default {
+  title: "Store/ProductList/ProductFilterBlock/SelectedProductFilterList/SelectedProductFilter",
+  component: SelectedProductFilter,
+} as ComponentMeta<typeof SelectedProductFilter>;
+
+const Template: ComponentStory<typeof SelectedProductFilter> = args => <SelectedProductFilter {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  name: "잇츠베러",
+};

--- a/src/components/Store/ProductList/ProductFilterBlock/SelectedProductFilterList/SelectedProductFilter/SelectedProductFilter.styles.ts
+++ b/src/components/Store/ProductList/ProductFilterBlock/SelectedProductFilterList/SelectedProductFilter/SelectedProductFilter.styles.ts
@@ -1,0 +1,30 @@
+import styled from "styled-components";
+
+export const SelectedProductFilterLayout = styled.button`
+  padding: 5px 10px;
+  background-color: #d9d9d9;
+  border-radius: 20px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  position: relative;
+`;
+
+export const SelectedProductFilterName = styled.span`
+  display: flex;
+  align-items: center;
+  &::after {
+    content: "X";
+    margin-left: 3px;
+    opacity: 0;
+  }
+`;
+
+export const SelectedProductFilterDeleteIcon = styled.div`
+  position: absolute;
+  top: 4px;
+  right: 8px;
+  background-color: #d9d9d9;
+  display: flex;
+  font-weight: 600;
+`;

--- a/src/components/Store/ProductList/ProductFilterBlock/SelectedProductFilterList/SelectedProductFilter/SelectedProductFilter.tsx
+++ b/src/components/Store/ProductList/ProductFilterBlock/SelectedProductFilterList/SelectedProductFilter/SelectedProductFilter.tsx
@@ -1,0 +1,20 @@
+import {
+  SelectedProductFilterDeleteIcon,
+  SelectedProductFilterLayout,
+  SelectedProductFilterName,
+} from "./SelectedProductFilter.styles";
+
+interface SelectedProductFilterProps {
+  name: string;
+}
+
+const SelectedProductFilter = ({ name }: SelectedProductFilterProps) => {
+  return (
+    <SelectedProductFilterLayout>
+      <SelectedProductFilterName>{name}</SelectedProductFilterName>
+      <SelectedProductFilterDeleteIcon>X</SelectedProductFilterDeleteIcon>
+    </SelectedProductFilterLayout>
+  );
+};
+
+export default SelectedProductFilter;

--- a/src/components/Store/ProductList/ProductFilterBlock/SelectedProductFilterList/SelectedProductFilterList.stories.tsx
+++ b/src/components/Store/ProductList/ProductFilterBlock/SelectedProductFilterList/SelectedProductFilterList.stories.tsx
@@ -1,0 +1,21 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import SelectedProductFilterList from "./SelectedProductFilterList";
+
+export default {
+  title: "Store/ProductList/ProductFilterBlock/SelectedProductFilterList",
+  component: SelectedProductFilterList,
+} as ComponentMeta<typeof SelectedProductFilterList>;
+
+const Template: ComponentStory<typeof SelectedProductFilterList> = args => <SelectedProductFilterList {...args} />;
+
+export const GeneralType = Template.bind({});
+GeneralType.args = {
+  selectedFilters: [
+    { text: "잇츠베러", name: null, value: "1" },
+    { text: "젤러스 스윗", name: null, value: "2" },
+    { text: "10000원이하", name: "price", value: "3" },
+    { text: "무료배송", name: null, value: "4" },
+    { text: "할인 상품", name: null, value: "5" },
+    { text: "품절상품제외", name: null, value: "6" },
+  ],
+};

--- a/src/components/Store/ProductList/ProductFilterBlock/SelectedProductFilterList/SelectedProductFilterList.styles.ts
+++ b/src/components/Store/ProductList/ProductFilterBlock/SelectedProductFilterList/SelectedProductFilterList.styles.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+export const SelectedProductFilterListLayout = styled.div`
+  display: inline-flex;
+  gap: 10px;
+  background-color: #f6f6f6;
+  padding: 15px;
+  margin: 20px 0 0 0;
+  height: 26px;
+`;

--- a/src/components/Store/ProductList/ProductFilterBlock/SelectedProductFilterList/SelectedProductFilterList.tsx
+++ b/src/components/Store/ProductList/ProductFilterBlock/SelectedProductFilterList/SelectedProductFilterList.tsx
@@ -1,0 +1,19 @@
+import { filterType } from "../../../../../pages/Store/ProductList";
+import SelectedProductFilter from "./SelectedProductFilter/SelectedProductFilter";
+import { SelectedProductFilterListLayout } from "./SelectedProductFilterList.styles";
+
+interface SelectedProductFilterList {
+  selectedFilters: filterType[];
+}
+
+const SelectedProductFilterList = ({ selectedFilters }: SelectedProductFilterList) => {
+  return (
+    <SelectedProductFilterListLayout>
+      {selectedFilters.map(({ text, value }) => (
+        <SelectedProductFilter name={text} key={value} />
+      ))}
+    </SelectedProductFilterListLayout>
+  );
+};
+
+export default SelectedProductFilterList;

--- a/src/hooks/useSetQueryMutate.ts
+++ b/src/hooks/useSetQueryMutate.ts
@@ -1,0 +1,24 @@
+import { AxiosResponse } from "axios";
+import { MutationFunction, useMutation, useQueryClient } from "react-query";
+
+const useSetQueryMutate = <T, F>(
+  promiseCallback: MutationFunction<AxiosResponse<T, unknown>>,
+  queryKey?: unknown[],
+  setQueryCallback?: (e: AxiosResponse<T, unknown>) => F,
+) => {
+  const queryClient = useQueryClient();
+  const mutateFn = useMutation(promiseCallback, {
+    onSuccess: e => {
+      if (queryKey && setQueryCallback) {
+        queryClient.setQueryData(queryKey, setQueryCallback(e));
+      }
+    },
+    onError: e => {
+      console.log(e);
+      alert("에러발생"); //추후 에러 로직이 개별로 필요하게될경우 인자로 넘겨받도록 하도록하겠습니다.
+    },
+  });
+  return mutateFn;
+};
+
+export default useSetQueryMutate;

--- a/src/hooks/useSortPaging.ts
+++ b/src/hooks/useSortPaging.ts
@@ -1,0 +1,15 @@
+import { useState } from "react";
+
+const useSortPaging = (initalPage: number, initalSort: string) => {
+  const [page, setPage] = useState(initalPage);
+  const [sort, setSort] = useState(initalSort);
+
+  return {
+    page,
+    sort,
+    setPage,
+    setSort,
+  };
+};
+
+export default useSortPaging;

--- a/src/hooks/useSuspenseQuery.ts
+++ b/src/hooks/useSuspenseQuery.ts
@@ -1,0 +1,14 @@
+import axios from "axios";
+import { useQuery } from "react-query";
+
+const useSuspenseQuery = <T>(queryKey: unknown[], url: string, onSuccess?: (data: T) => void) => {
+  const { data } = useQuery<T>(queryKey, () => axios(`http://localhost:8000/${url}`).then(res => res.data), {
+    suspense: true,
+    useErrorBoundary: true,
+    onSuccess,
+  });
+
+  return { data: data as T };
+};
+
+export default useSuspenseQuery;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,19 +4,17 @@ import App from "./App";
 import { RecoilRoot } from "recoil";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { BrowserRouter } from "react-router-dom";
+import { ReactQueryDevtools } from "react-query/devtools";
 
 const queryClient = new QueryClient();
-const root = ReactDOM.createRoot(
-  document.getElementById("root") as HTMLElement
-);
+const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
 root.render(
   <RecoilRoot>
-    <React.StrictMode>
-      <QueryClientProvider client={queryClient}>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
-      </QueryClientProvider>
-    </React.StrictMode>
-  </RecoilRoot>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+      <ReactQueryDevtools initialIsOpen={false} position="bottom-right" />
+    </QueryClientProvider>
+  </RecoilRoot>,
 );

--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -1,8 +1,0 @@
-import React from "react";
-import HeaderContainer from "../components/Common/Header/HeaderContainer";
-
-function Store() {
-  return <HeaderContainer />;
-}
-
-export default Store;

--- a/src/pages/Store/ProductDetail.tsx
+++ b/src/pages/Store/ProductDetail.tsx
@@ -1,0 +1,25 @@
+import { Suspense, useState } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import { useLocation } from "react-router-dom";
+import CategoryNavigation from "../../components/Store/Common/CategoryNavigation/CategoryNavigation";
+import DetailContainer from "../../components/Store/ProductDetail/Detail/DetailContainer";
+import SummaryContainer from "../../components/Store/ProductDetail/Summary/SummaryContainer";
+import { conditionType } from "./ProductList";
+
+const ProductDetail = () => {
+  const location = useLocation();
+  const [condition, setCondition] = useState<{ category?: string }>({ category: location.state?.category });
+  return (
+    <main>
+      <CategoryNavigation condition={condition as conditionType} setCondition={() => null} />
+      <ErrorBoundary FallbackComponent={() => <div>...에러발생</div>}>
+        <Suspense fallback={<div>...로딩중</div>}>
+          <SummaryContainer setCondition={setCondition} />
+        </Suspense>
+      </ErrorBoundary>
+      <DetailContainer />
+    </main>
+  );
+};
+
+export default ProductDetail;

--- a/src/pages/Store/ProductList.tsx
+++ b/src/pages/Store/ProductList.tsx
@@ -1,0 +1,65 @@
+import React, { Suspense, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import HeaderContainer from "../../components/Common/Header/HeaderContainer";
+import CategoryNavigation from "../../components/Store/Common/CategoryNavigation/CategoryNavigation";
+import ProductCardListContainer from "../../components/Store/ProductList/ProductCardList/ProductCardListContainer";
+import ProductFilterBlockContainer from "../../components/Store/ProductList/ProductFilterBlock/ProductFilterBlockContainer";
+import AdCarousel from "../../components/Store/ProductList/ProductCarousel/ProductCarousel";
+import { ErrorBoundary } from "react-error-boundary";
+import ProductCarouselContainer from "../../components/Store/ProductList/ProductCarousel/ProductCarouselContainer";
+
+export interface filterType {
+  name: string | null;
+  value: string;
+  text: string;
+}
+export interface conditionType {
+  category: string;
+  filter: filterType[];
+  sort: string;
+  page: number;
+}
+
+export type setConditionType = React.Dispatch<conditionType>;
+
+function Store() {
+  const [condition, setCondition] = useState<conditionType>({
+    category: "전체",
+    filter: [],
+    sort: "인기순",
+    page: 1,
+  });
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const filterQuery = `&filter=${condition.filter.map(({ text }) => text).join("%")}`;
+    navigate(
+      `/store?category=${condition.category}${condition.filter.length ? filterQuery : ""}&sort=${condition.sort}&page=${
+        condition.page
+      }`,
+    );
+  }, [condition]);
+
+  return (
+    <>
+      <CategoryNavigation condition={condition} setCondition={setCondition} />
+      {condition.category === "전체" ? (
+        <ErrorBoundary FallbackComponent={() => <div>...에러발생</div>}>
+          <Suspense fallback={<div>...로딩중</div>}>
+            <ProductCarouselContainer />
+          </Suspense>
+        </ErrorBoundary>
+      ) : null}
+      {condition.category === "전체" ? null : (
+        <ProductFilterBlockContainer condition={condition} setCondition={setCondition} />
+      )}
+      <ErrorBoundary FallbackComponent={() => <div>...에러발생</div>}>
+        <Suspense fallback={<div>...로딩중</div>}>
+          <ProductCardListContainer condition={condition} setCondition={setCondition} />
+        </Suspense>
+      </ErrorBoundary>
+    </>
+  );
+}
+
+export default Store;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,6 +55,7 @@ module.exports = {
     historyApiFallback: true,
   },
   output: {
+    publicPath: "/",
     path: path.join(__dirname, "build"),
     filename: "[name].js",
   },


### PR DESCRIPTION
<!-- 제목에 반드시 이슈토큰을 포함해주세요
ex) 메인페이지 작업 ZERO-4 -->

## 제목
store 페이지 와이어 프레임 작업하였습니다.

## 작업내용
- webpack이 url 을 기준으로 파일을 로드하지 않도록 수정하여 main.js를 올바로 가져올수 있도록 수정
- errorboundary 컴포넌트 사용을 위한 react-error-boundary 라이브러리 설치
- storybook 액션 사용을 위한 애드온 추가 및 라우팅 설정( 글로벌 styles 적용 바로하겠습니다)
- useSuspense라는 useQuery 기반의 hook 구현 suspense,errorbounder 및 이후 sucess 시처리 가능합니다. 추후 요건에 따라서 수정해서 사용하면 좋을것 같습니다.
- useSetQueryMutate 라는 useMutate 기반의 hook 구현 post, delete 이후 query 데이터 수정기능이있습니다. hook 이 약간 복잡한데, 가능하면 데이터 수정시 새로 받아오지말고, 기존의 데이터를 변경시키는것이 속도 측면에서 좋을것 같아서 이렇게 구현하였습니다.
- useSortPaging 를 구현하였습니다. sort 와 page를 같이 처리하는 단순한 hook 입니다. 중복적으로 필요해서 분리하였습니다. 추후 확장가능성이 있습니다.
- 장바구니, 구매, 좋아요 표시등 유저 로그인 과 관련된 기능은 로그인 확인 방식 합의후 구현할계획입니다. 지금은 간단하게 구현되어있습니다.
- page 폴더에서 도메인별로 다른 페이지를 유지할수있도록 도메인별로 폴더로 관리하도록 수정하였습니다.(next.js와 동일합니다)

## 주의사항
- 데이터 타입등은 제가 임의로 정한 값들입니다. 추후 백엔드와의 협의하에 수정할 예정입니다.
- 데이터 받아오거나 수정하는 부분은 로컬 api 서버를 이용하였기에 오류가 날수 있습니다. 혹시 필요하시면 서버 파일을 올려드리겠습니다.
